### PR TITLE
Remove Android reference in 6.2.3

### DIFF
--- a/input/Bio cPP.md
+++ b/input/Bio cPP.md
@@ -655,7 +655,7 @@ For example, \[NIST800-63B\] requires that FMR shall be 1 in 1000 or
 lower. \[ISO21879\] is proposing that FAR would be 1 in 10000 or lower
 that is equal to a conventional four-digit PIN-Code for secure
 transaction. Several mobile vendors have specified fingerprint 
-verification on small sensors shall have the FAR lower than 0.002% and 
+verification shall have the FAR lower than 0.002% and 
 recommended to have the FRR lower than 10%. The cPP doesn’t provide 
 any recommendation for those error rates however, ST author should set 
 appropriate error rates referring those value.


### PR DESCRIPTION
I have removed the Android reference in 6.2.3 and modified it to be more "generic". This is specifically for #95 with the statement to remove Android CDD from the mention.

Here I have suggested keeping the recommendation of several vendors as a reference. I have removed the Android reference and tweaked the wording. [Microsoft](https://docs.microsoft.com/en-us/windows-hardware/design/device-experiences/windows-hello-biometric-requirements) also has a similar reference to match the Android CDD, and I thought it worth keeping the mention that there is some level of agreement in industry to these numbers.

If no one else sees value in this edit though, I would not be against just removing the sentence in its entirety.