### PR TITLE
Move pad req to optional

### DIFF
--- a/3_ProtectionProfile/BiocPP.adoc
+++ b/3_ProtectionProfile/BiocPP.adoc
@@ -146,7 +146,7 @@ Zero-effort Impostor Attempt::
 - PP-Module Date: {revdate}
 
 === Base PP identification
-Base PP of this PP-Module is <<MDFPP>>.
+Base PP of this PP-Module is identified in the appropriate PP-Configuration.
 
 === TOE Overview
 ==== TOE main security features
@@ -217,7 +217,7 @@ The requirements for the TOE focus on the biometric performance (FTE, FAR/FMR an
 
 == Consistency rationale
 
-Consistency between the <<MDFPP>> and this PP-Module is demonstrated in the <<PPC-MDF>>.
+Consistency between the base PP and this PP-Module is demonstrated in the appropriate PP-Configuration.
 
 == Conformance Claims
 
@@ -427,25 +427,25 @@ Target error rates defined in SFR shall be evaluated based on <<SD>>. Normally t
 
 *FPT_BDP_EXT.1.1* The TSF shall process any plaintext biometric data used to generate templates and perform sample matching within the security boundary of the secure execution environment.
 
-*Application Note {counter:remark_count}*:: The Consistency Rationale in the <<PPC-MDF>> explains how the biometric system in cooperation with the mobile device shall protect biometric data in detail.
+*Application Note {counter:remark_count}*:: The Consistency Rationale in the appropriate PP-Configuration explains how the TOE in cooperation with its environment shall protect biometric data in detail.
 
 ==== FPT_BDP_EXT.2 No Biometric data transmission [[FPT_BDP_EXT.2]]
 
 *FPT_BDP_EXT.2.1* The TSF shall not transmit any plaintext biometric data outside the security boundary of the secure execution environment.
 
-*Application Note {counter:remark_count}*:: The Consistency Rationale in the <<PPC-MDF>> explains how the biometric system in cooperation with the mobile device shall protect biometric data in detail.
+*Application Note {counter:remark_count}*:: The Consistency Rationale in the appropriate PP-Configuration explains how the TOE in cooperation with its environment shall protect biometric data in detail.
 
 ==== FPT_BDP_EXT.3 Biometric data storage [[FPT_BDP_EXT.3]]
 
 [[FPT_BDP_EXT.3.1]]*FPT_BDP_EXT.3.1* The TSF shall not store any plaintext biometric data outside the security boundary of the secure execution environment.
 
-*Application Note {counter:remark_count}*:: The Consistency Rationale in the <<PPC-MDF>> explains how the biometric system in cooperation with the mobile device shall protect biometric data in detail.
+*Application Note {counter:remark_count}*:: The Consistency Rationale in the appropriate PP-Configuration explains how the TOE in cooperation with its environment shall protect biometric data in detail.
 
 ==== FPT_PBT_EXT.1 Protection of biometric template [[FPT_PBT_EXT.1]]
 
 *FPT_PBT_EXT.1.1*:: The TSF shall protect the template [*selection*: _using a PIN as an additional factor, using a password as an additional factor_, [*assignment*: _other circumstances_]].
 
-*Application Note {counter:remark_count}*:: The Consistency Rationale in the <<PPC-MDF>> explains how the biometric system in cooperation with the mobile device shall protect biometric data in detail.
+*Application Note {counter:remark_count}*:: The Consistency Rationale in the appropriate PP-Configuration explains how the TOE in cooperation with its environment shall protect biometric data in detail.
 
 == Security Assurance Requirements
 
@@ -483,7 +483,7 @@ ST authors are free to choose none, some or all SFRs defined in this Section. Ju
 
 *FDP_RIP.2.1* The TSF shall ensure that any previous information content of biometric data is made unavailable upon the [*selection*: _allocation of the resource to, deallocation of the resource from_] all objects.
 
-*Application Note {counter:remark_count}*:: The Consistency Rationale in the <<PPC-MDF>> explains how the biometric system in cooperation with the mobile device shall protect biometric data in detail.
+*Application Note {counter:remark_count}*:: The Consistency Rationale in the appropriate PP-Configuration explains how the TOE in cooperation with its environment shall protect biometric data in detail.
 
 == Extended Component Definitions
 This appendix contains the definitions for the extended requirements that are used in the PP-Module, including those used in <<Optional Requirements>>. 

--- a/3_ProtectionProfile/BiocPP.adoc
+++ b/3_ProtectionProfile/BiocPP.adoc
@@ -3,9 +3,10 @@
 :toc:
 :toclevels: 3
 :sectnums:
+:sectnumlevels: 5
 :imagesdir: images
-:revnumber: 0.9
-:revdate: 2019-08-05
+:revnumber: 0.91
+:revdate: 2019-12-05
 
 :iTC-longame: Biometrics Security
 :iTC-shortname: BIO-iTC
@@ -34,7 +35,9 @@ Although the PP-Module and <<SD>> may contain minor editorial errors, the PP-Mod
 - [#CC3]#[CC3]#	Common Criteria for Information Technology Security Evaluation, Part 3: Security Assurance Components, CCMB-2017-04-003, Version 3.1 Revision 5, April 2017.
 - [#CEM]#[CEM]#	Common Methodology for Information Technology Security Evaluation, Evaluation Methodology, CCMB-2017-04-004, Version 3.1 Revision 5, April 2017.
 - [#addenda]#[addenda]#	CC and CEM addenda, Exact Conformance, Selection-Based SFRs, Optional SFRs, Version 0.5, May 2017.
-- [#SD]#[SD]# Evaluation Activities for collaborative Protection Profile Module for Biometric enrolment and verification - for unlocking the device -, January-2019, Version 0.3.
+- [#MDFPP]#[MDFPP]# Protection Profile for Mobile Device Fundamentals, Version:3.3.
+- [#PPC-MDF]#[PPC-MDF]# PP-Configuration for Protection Profile for Mobile Device Fundamentals and collaborative PP-Module for Biometric enrolment and verification - for unlocking the device -, December 05, 2019, Version 0.91.
+- [#SD]#[SD]# Evaluation Activities for collaborative Protection Profile Module for Biometric enrolment and verification - for unlocking the device -, December 05, 2019, Version 0.5.
 - [#ISOIEC19795-1]#[ISO/IEC 19795-1]# Biometric performance testing and reporting — Part 1: Principles and framework, First edition.
 - [#ISOIEC19989-2]#[ISO/IEC 19989-2]# Information technology - Security techniques - Criteria and methodology for security evaluation of biometric systems - Part 2: Biometric recognition performance
 - [#ISO19989-3]#[ISO/IEC 19989-3]# Information technology - Security techniques - Criteria and methodology for security evaluation of biometric systems - Part 3: Presentation attack detection
@@ -129,14 +132,21 @@ Zero-effort Impostor Attempt::
 |0.9
 |5th August, 2019
 |Updates based on Public Review Draft 1 comments
+
+|0.9
+|5th December, 2019
+|Updates to make PAD optional
 |===
 
-== PP Introduction
+== PP-Module Introduction
 
-=== PP Reference Identification
-- PP Reference: {doctitle}
-- PP Version: {revnumber}
-- PP Date: {revdate}
+=== PP-Module Reference
+- PP-Module Reference: {doctitle}
+- PP-Module Version: {revnumber}
+- PP-Module Date: {revdate}
+
+=== Base PP identification
+Base PP of this PP-Module is <<MDFPP>>.
 
 === TOE Overview
 This is a collaborative Protection Profile Module (PP-Module) that is used to extend a base PP for a mobile device that implement biometric enrolment and verification to unlock the mobile device in the locked state using user’s biometric characteristics. Therefore, the Target of Evaluation (TOE) in this PP-Module is a mobile device that implements biometric enrolment and verification functionality. However, the term TOE in this document expresses the biometric system that is a part of the TOE (i.e. mobile device) and implements the biometric enrolment and verification functionality for clearly describing the relation and boundary between the biometric system and mobile device. Each biometric enrolment and verification process is described in the following paragraphs. 
@@ -153,11 +163,7 @@ During the verification process, a user presents his/her own biometric character
 
 Examples of biometric characteristic used by the TOE are: fingerprint, face, eye, palm print, finger vein, palm vein, speech, signature and so forth. However, scope of this PP-Module is limited to only those biometric characteristics for which <<SD>> defines the Evaluation Activities.
 
-c)	Presentation Attack Detection (PAD)
-
-The TOE needs to consider the risk of subverting the TOE’s biometric verification. Attacker could present artificial PAIs to the TOE to interfere with the TOE’s security objectives. The TOE needs to be able to provide resistance to presentation attacks. <<SD>> explains what resistance should be provided by the TOE in detail.
-
-=== TOE Design
+==== TOE Design
 The TOE is fully integrated into the mobile device without the need for additional software and hardware. The following figure, inspired from <<ISO30107-1,ISO/IEC 30107-1>>, is a generic representation of a TOE. It should be noted that the actual TOE design may not directly correspond to this figure and the developer may design the TOE in a different way. This illustrates the different sub-functionalities on which the biometric enrolment and verification processes rely on.
 
 [#img-TOE-generic]
@@ -170,10 +176,10 @@ As illustrated in the above figure, the TOE is capable of:
 * Extracting and processing the features from samples of sufficient quality and generating various templates (Signal Processing Subsystem)
 * Storing the templates in a database on the mobile device (Data Storage Subsystem)
 * Comparing captured features with data contained in one or more templates (Comparison Subsystem)
-* Detecting the presentation attacks using artificial PAI (Presentation Attack Detection Subsystem)
+* Optionally detecting the presentation attacks using artificial PAI (Presentation Attack Detection Subsystem)
 * Deciding how well features and any template match, and indicating whether or not a verification of the user has been achieved (Decision Subsystem)
 
-=== Relation between TOE and mobile device 
+==== Relation between TOE and mobile device 
 The TOE is reliant on the mobile device itself to provide overall security of the system. This PP-Module is intended to be used with a base PP, and the base PP is responsible for evaluating the following security functions:
 
 * Providing the Password Authentication Factor to support user authentication and management of the TOE security function
@@ -186,36 +192,50 @@ The evaluation of the above security functions is out of scope of this PP-Module
 .Generic relations between the TOE and the mobile device environment
 image::BiocPP_architecture_proposal_3.png[title="Generic relations between the TOE and the mobile device environment" align="center"]
 
-=== TOE Use Case
-Mobile device itself may be operated in a number of use cases such as enterprise use with limited personal use or Bring Your Own Device (BYOD). The TOE on the device may also be operated in the same use cases, however, use cases of the TOE should be devised separately considering the purpose of mobile biometric verification and potential attacks. The following use cases describe how and why mobile biometric verification is supposed to be used. Each use case has its own assurance level, depending on its criticality and separate PP or PP-Module should be developed for each use case.  
+==== TOE Use Case
+Mobile device itself may be operated in a number of use cases such as enterprise use with limited personal use or Bring Your Own Device (BYOD). The TOE on the device may also be operated in the same use cases, however, use cases of the TOE should be devised separately considering the purpose of biometric verification. The following use cases describe how and why biometric verification is supposed to be used. Each use case has its own assurance level, depending on its criticality and separate PP or PP-Module should be developed for each use case.  
 
 This PP-Module only assumes USE CASE 1 described below. USE CASE 2 is out of scope of this PP-Module.
 
-==== USE CASE 1: Biometric verification for unlocking the mobile device
-For enhanced security that is easy to use, mobile device may implement mobile biometric verification on a device once it has been “unlocked”. The initial unlock is generally done by a PIN/password which is required at startup (or possibly after some period of time), and after that the user is able to use an own biometric characteristic to unlock access to the mobile device. In this use case, the mobile device is not supposed to be used for security sensitive services through the mobile biometric verification.
+===== USE CASE 1: Biometric verification for unlocking the mobile device
+For enhanced security that is easy to use, mobile device may implement mobile biometric verification on a device once it has been “unlocked”. The initial unlock is generally done by a PIN/password which is required at startup (or possibly after some period of time), and after that the user is able to use an own biometric characteristic to unlock access to the mobile device. In this use case, the mobile device is not supposed to be used for security sensitive services through the biometric verification.
 
-Main concern of this use case is the accuracy of mobile biometric verification (i.e. FAR/FMR and FRR/FNMR) and basic level of presentation attacks. Security assurance for mobile device that the TOE relies on should be handled by the base PP.
+Main concern of this use case is the accuracy of the biometric verification (i.e. FAR/FMR and FRR/FNMR). Security assurance for mobile device that the TOE relies on should be handled by the base PP.
 
-This use case assumes that the mobile device is configured correctly to enable the mobile biometric verification by the biometric system administrator. The user of the mobile device can act as the biometric system administrator in this use case.
+This use case assumes that the mobile device is configured correctly to enable the biometric verification by the biometric system administrator. The user of the mobile device can act as the biometric system administrator in this use case.
 
-It is also assumed that the user enrols his/herself correctly, following the guidance provided by the TOE. Attacks during enrolment may be out of scope, but optionally addressed. FTE is not a security relevant criterion for this use case.
+It is also assumed that the user enrols his/herself correctly, following the guidance provided by the TOE. Presentation attacks during biometric enrolment and verification may be out of scope, but optionally addressed. FTE is not a security relevant criterion for this use case.
 
-==== USE CASE 2: Biometric verification for security sensitive service
+===== USE CASE 2: Biometric verification for security sensitive service
 
-This use case is an example of another use case that isn’t considered in this PP-Module. Another PP-Module should be developed at higher assurance level for this use case.
+This use case is an example of another use case that isn’t considered in this PP-Module. Another PP or PP-Module should be developed at higher assurance level for this use case.
 
 Mobile devices may be used for security sensitive services such as payment transactions and online banking. Verification may be done by the biometric for convenience instead of PIN/password to access such security sensitive services.
 
-The requirements for the TOE focus on the biometric performance (FTE, FAR/FMR and FRR/FNMR) and higher level of presentation attack.
+The requirements for the TOE focus on the biometric performance (FTE, FAR/FMR and FRR/FNMR) and presentation attack detection.
 
-== CC Conformance Claims
+== Consistency rationale
+
+Consistency between SPD/objectives/SFRs in <<MDFPP>> and this PP-Module is demonstrated in the <<PPC-MDF>>.
+
+== Conformance Claims
+
+=== Conformance statement
+
 As defined by the references <<CC1>>, <<CC2>> and <<CC3>>, this PP-Module:
 
 * conforms to the requirements of Common Criteria v3.1, Revision 5,
 * is Part 2 extended,
+* all assurance requirements are inherited from the base PP
 * does not claim conformance to any other security functional requirement packages.
 
-In order to be conformant to this PP-Module, a ST shall demonstrate Exact Conformance. Exact Conformance, as a subset of Strict Conformance as defined by the CC, is defined as the ST containing all of the SFRs in <<Security Functional Requirements>> (these are the mandatory SFRs) of this PP-Module, and potentially SFRs from <<Selection-Based Requirements>> (these are selection-based SFRs) and <<Optional Requirements>> (these are optional SFRs) of this PP-Module. While iteration is allowed, no additional requirements (from [CC2] or [CC3], or definitions of extended components not already included in this PP-Module) are allowed to be included in the ST. Further, no SFRs in <<Security Functional Requirements>> of this PP-Module are allowed to be omitted.
+=== Conformance type
+
+In order to be conformant to this PP-Module, a ST shall demonstrate Exact Conformance. Exact Conformance requires the ST to contain all of the SFRs in <<Security Functional Requirements>> (these are the mandatory SFRs). The ST may includes <<Optional Requirements>> (these are optional SFRs) of this PP-Module. While iteration is allowed, no additional requirements (from [CC2] or [CC3], or definitions of extended components not already included in this PP-Module) are allowed to be included in the ST. Further, no SFRs in <<Security Functional Requirements>> of this PP-Module are allowed to be omitted.
+
+=== Evaluation activities
+
+This PP-Module requires the use of evaluation activities defined in <<SD>>.
 
 == Security Problem Definition
 

--- a/3_ProtectionProfile/BiocPP.adoc
+++ b/3_ProtectionProfile/BiocPP.adoc
@@ -55,7 +55,7 @@ For the purpose of this PP-Module, the following terms and definitions given in 
 Attempt::
    Submission of one (or a sequence of) biometric samples to the part of the TOE.
 Biometric Authentication Factor (BAF)::
-	Authentication factor used for mobile biometric verification. In this PP-Module, the term is a synonym of the “template”.
+	Authentication factor used for biometric verification. In this PP-Module, the term is a synonym of the “template”.
 Biometric Data::
 	Digital data created during biometric enrolment and verification processes. It encompasses raw sensor observations, biometric samples, features, templates, and/or similarity scores, among other data. This data is used to describe the information collected, and does not include end user information such as user name, password (unless tied to the biometric modality), demographic information, and authorizations.
 Biometric System Administrator::
@@ -149,6 +149,7 @@ Zero-effort Impostor Attempt::
 Base PP of this PP-Module is <<MDFPP>>.
 
 === TOE Overview
+==== TOE main security features
 This is a collaborative Protection Profile Module (PP-Module) that is used to extend a base PP for a mobile device that implement biometric enrolment and verification to unlock the mobile device in the locked state using user’s biometric characteristics. Therefore, the Target of Evaluation (TOE) in this PP-Module is a mobile device that implements biometric enrolment and verification functionality. However, the term TOE in this document expresses the biometric system that is a part of the TOE (i.e. mobile device) and implements the biometric enrolment and verification functionality for clearly describing the relation and boundary between the biometric system and mobile device. Each biometric enrolment and verification process is described in the following paragraphs. 
 
 a)	Biometric enrolment
@@ -198,7 +199,7 @@ Mobile device itself may be operated in a number of use cases such as enterprise
 This PP-Module only assumes USE CASE 1 described below. USE CASE 2 is out of scope of this PP-Module.
 
 ===== USE CASE 1: Biometric verification for unlocking the mobile device
-For enhanced security that is easy to use, mobile device may implement mobile biometric verification on a device once it has been “unlocked”. The initial unlock is generally done by a PIN/password which is required at startup (or possibly after some period of time), and after that the user is able to use an own biometric characteristic to unlock access to the mobile device. In this use case, the mobile device is not supposed to be used for security sensitive services through the biometric verification.
+For enhanced security that is easy to use, mobile device may implement biometric verification on a device once it has been “unlocked”. The initial unlock is generally done by a PIN/password which is required at startup (or possibly after some period of time), and after that the user is able to use an own biometric characteristic to unlock access to the mobile device. In this use case, the mobile device is not supposed to be used for security sensitive services through the biometric verification.
 
 Main concern of this use case is the accuracy of the biometric verification (i.e. FAR/FMR and FRR/FNMR). Security assurance for mobile device that the TOE relies on should be handled by the base PP.
 
@@ -216,7 +217,7 @@ The requirements for the TOE focus on the biometric performance (FTE, FAR/FMR an
 
 == Consistency rationale
 
-Consistency between SPD/objectives/SFRs in <<MDFPP>> and this PP-Module is demonstrated in the <<PPC-MDF>>.
+Consistency between the <<MDFPP>> and this PP-Module is demonstrated in the <<PPC-MDF>>.
 
 == Conformance Claims
 
@@ -226,8 +227,8 @@ As defined by the references <<CC1>>, <<CC2>> and <<CC3>>, this PP-Module:
 
 * conforms to the requirements of Common Criteria v3.1, Revision 5,
 * is Part 2 extended,
-* all assurance requirements are inherited from the base PP
-* does not claim conformance to any other security functional requirement packages.
+* all assurance requirements are inherited from the base PP,
+* does not claim conformance to any other security functional packages.
 
 === Conformance type
 
@@ -250,30 +251,24 @@ Note that as a PP-Module, all threats, assumptions, and OSPs defined in the base
 [[T.Casual_Attack]]T.Casual_Attack::
 An attacker may attempt to impersonate as a legitimate user without being enrolled in the TOE. In order to perform the attack, the attacker only use his/her own biometric characteristic (in form of a zero-effort impostor attempt).
 
-[[T.Presentation_Attack]]T.Presentation_Attack::
-An attacker may attempt a presentation attack to the TOE. In order to perform the attack, the attacker uses artificial Presentation Attack Instrument (PAI) except his/her own biometric characteristic.
-
 === Organizational Security Policies
 
 [[OSP.Enrol]]OSP.Enrol::
-The TOE shall enrol a user for mobile biometric verification, only after successful authentication of a user. The TOE shall ensure that templates are of sufficient quality in order to meet the relevant error rates for mobile biometric verification.
-
-[[OSP.PAD_Error]]OSP.PAD_Error::
-The TOE shall meet relevant criteria for its security relevant error rates for PAD.
+The TOE shall enrol a user for biometric verification, only after successful authentication of a user. The TOE shall ensure that templates are of sufficient quality in order to meet the relevant error rates for biometric verification.
 
 [[OSP.Protection]]OSP.Protection::
 The TOE in cooperation with its environment shall protect itself, its configuration and biometric data.
 
 [[OSP.Verification_Error]]OSP.Verification_Error::
-The TOE shall meet relevant criteria for its security relevant error rates for mobile biometric verification.
+The TOE shall meet relevant criteria for its security relevant error rates for biometric verification.
 
 === Assumptions
 
 [[A.Alternative]]A.Alternative::
-It is assumed that the TOE environment provides an alternative authentication mechanism as a complement to mobile biometric verification. The alternative authentication mechanism is required for enrolment of the biometric template and can also be used in cases when a user is rejected by the mobile biometric verification (False Rejection).
+It is assumed that the TOE environment provides an alternative authentication mechanism as a complement to biometric verification. The alternative authentication mechanism is required for enrolment of the biometric template and can also be used in cases when a user is rejected by the biometric verification (False Rejection).
 
 [[A.Authentication]]A.Authentication::
-It is assumed that the TOE environment invokes the TOE for mobile biometric verification, and take appropriate actions based on the TOE’s decision.
+It is assumed that the TOE environment invokes the TOE for biometric verification, and take appropriate actions based on the TOE’s decision.
 
 [[A.User]]A.User::
 It is assumed that the user configures the TOE and its environment correctly in a manner to ensure that the TOE security policies will be enforced.
@@ -284,16 +279,16 @@ This PP-Module defines the following security objectives.
 === Security Objectives for the TOE
 
 [[O.BIO_Verification]]O.BIO_Verification::
-The TOE shall provide a mobile biometric verification mechanism to verify a user with an adequate reliability. The TOE shall meet the relevant criteria for its security relevant error rates for mobile biometric verification.
+The TOE shall provide a biometric verification mechanism to verify a user with an adequate reliability. The TOE shall meet the relevant criteria for its security relevant error rates for biometric verification.
 
 SFR Rationale:
 
-Requirements to provide a mobile biometric verification mechanism is defined in FIA_MBV_EXT.1 in which ST author can specify the relevant criteria for its security relevant error rates. FIA_MBV_EXT.2 requires the TOE to only use samples of sufficient quality to verify a user with an adequate reliability.
+Requirements to provide a biometric verification mechanism is defined in FIA_MBV_EXT.1 in which ST author can specify the relevant criteria for its security relevant error rates. FIA_MBV_EXT.2 requires the TOE to only use samples of sufficient quality to verify a user with an adequate reliability.
 
 *Application Note {counter:remark_count}*:: In this PP-Module, relevant criteria are FAR/FMR and FRR/FNMR and corresponding error rates shall be specified in the FIA_MBV_EXT.1.
 
 [[O.Enrol]]O.Enrol::
-The TOE shall implement the functionality to enrol a user for mobile biometric verification and bind the template to the user only after successful authentication of the user to the TOE environment using an alternative authentication mechanism. The TOE shall create the sufficient quality of templates in order to meet the relevant error rates for mobile biometric verification.
+The TOE shall implement the functionality to enrol a user for biometric verification and bind the template to the user only after successful authentication of the user to the TOE environment using an alternative authentication mechanism. The TOE shall create the sufficient quality of templates in order to meet the relevant error rates for biometric verification.
 
 SFR Rationale:
 
@@ -302,17 +297,6 @@ Requirements to provide a biometric enrolment mechanism is defined in FIA_MBE_EX
 *Application Note {counter:remark_count}*:: A user shall be authenticated using a Password Authentication Factor to enrol his/herself.
 
 *Application Note {counter:remark_count}*:: In this PP-Module, relevant criteria are FAR/FMR and FRR/FNMR and corresponding error rates shall be specified in the FIA_MBV_EXT.1.
-
-[[O.Presentation_Attack_Detection]]O.Presentation_Attack_Detection::
-The TOE shall prevent a presentation attack using artificial PAIs. The TOE shall meet relevant criteria for its security relevant error rates for PAD.
-
-SFR Rationale:
-
-Requirement to provide a presentation attack detection mechanism during mobile biometric verification is defined in FIA_MBV_EXT.3. <<SD>> defines relevant criteria for its security relevant error rates for PAD. Optional requirement to provide a presentation attack detection mechanism during biometric enrolment is defined as FIA_MBE_EXT.3.
-
-*Application Note {counter:remark_count}*:: The TOE may or may not counter a presentation attack during enrolment. If the ST author requires the TOE to counter the presentation attack during enrolment, ST author should include FIA_MBE_EXT.3 defined in <<Optional Requirements>>.
-
-*Application Note {counter:remark_count}*:: According to the <<ISO30107-3,ISO/IEC 30107-3>>, relevant error rates should be specified for each type of PAI. <<SD>> defines PAIs that should be used for attack and describes how to create and present the PAIs to the TOE, and minimum error rates that the TOE shall achieve.
 
 [[O.Protection]]O.Protection::
 The TOE shall protect biometric data using the secure execution environment provided by the TOE environment.
@@ -326,14 +310,14 @@ Requirements to control access to the template is defined in FPT_PBT_EXT.1. FPT_
 === Security Objectives for the Operational Environment
 
 [[OE.Alternative]]OE.Alternative::
-The TOE environment shall provide an alternative authentication mechanism as a complement to mobile biometric verification. The alternative authentication mechanism is required for enrolment of the biometric template and can also be used in cases where a user is rejected by the mobile biometric verification (False Rejection).
+The TOE environment shall provide an alternative authentication mechanism as a complement to biometric verification. The alternative authentication mechanism is required for enrolment of the biometric template and can also be used in cases where a user is rejected by the biometric verification (False Rejection).
 
 *Application Note {counter:remark_count}*:: The TOE environment (i.e. mobile device) shall satisfy relevant requirements defined in base PP.
 
 *Application Note {counter:remark_count}*:: The TOE environment (i.e. mobile device) shall provide an alternative authentication mechanism such as a Password Authentication Factor.
 
 [[OE.Authentication]]OE.Authentication::
-The TOE environment shall invoke the TOE for mobile biometric verification, and take appropriate actions based on the TOE’s decision.
+The TOE environment shall invoke the TOE for biometric verification, and take appropriate actions based on the TOE’s decision.
 
 *Application Note {counter:remark_count}*:: Appropriate actions taken by the mobile device are unlocking the mobile device or incrementing the number of unsuccessful attempts and limiting maximum number of unsuccessful attempts.
 
@@ -356,15 +340,11 @@ The following table describes how the assumptions, threats, and organizational s
 
 |<<T.Casual_Attack>> <<OSP.Verification_Error>>	
 |<<O.BIO_Verification>>	
-|The threat <<T.Casual_Attack>> is countered by <<O.BIO_Verification>> as this provides the capability of mobile biometric verification not to allow the user who have not been enrolled to impersonate as a legitimate user. The OSP <<OSP.Verification_Error>> is enforced by <<O.BIO_Verification>> as this requires the TOE to meet relevant criteria for security relevant error rates for mobile biometric verification.
+|The threat <<T.Casual_Attack>> is countered by <<O.BIO_Verification>> as this provides the capability of biometric verification not to allow the user who have not been enrolled to impersonate as a legitimate user. The OSP <<OSP.Verification_Error>> is enforced by <<O.BIO_Verification>> as this requires the TOE to meet relevant criteria for security relevant error rates for biometric verification.
 
 |<<OSP.Enrol>>	
 |<<O.Enrol>>	
-|The OSP <<OSP.Enrol>> is enforced by <<O.Enrol>> as this require the TOE to implement the functionality to enrol a user for mobile biometric verification and create sufficient quality of templates.
-
-|<<T.Presentation_Attack>> <<OSP.PAD_Error>>	
-|<<O.Presentation_Attack_Detection>>	
-|The threat <<T.Presentation_Attack>> is countered by <<O.Presentation_Attack_Detection>> as this provides the capability of mobile biometric verification to prevent attacks with artificial PAIs. The OSP <<OSP.PAD_Error>> is enforced by <<O.Presentation_Attack_Detection>> as this requires the TOE to meet relevant criteria for security relevant error rates for PAD.
+|The OSP <<OSP.Enrol>> is enforced by <<O.Enrol>> as this require the TOE to implement the functionality to enrol a user for biometric verification and create sufficient quality of templates.
 
 |<<OSP.Protection>>	
 |<<O.Protection>> <<OE.Protection>>	
@@ -411,9 +391,9 @@ Extended SFRs are identified by having a label “EXT” at the end of the SFR n
 
 ==== FIA_MBV_EXT.1 Biometric verification [[FIA_MBV_EXT.1]]
 
-*FIA_MBV_EXT.1.1*:: The TSF shall provide a mobile biometric verification mechanism using [*selection*: _fingerprint, eye, face, voice, vein_, [*assignment*: _other modality_]].
+*FIA_MBV_EXT.1.1*:: The TSF shall provide a biometric verification mechanism using [*selection*: _fingerprint, eye, face, voice, vein_, [*assignment*: _other modality_]].
 
-*FIA_MBV_EXT.1.2*:: The TSF shall provide a mobile biometric verification mechanism with the [*selection*: _FMR, FAR_] not exceeding [*assignment*: _defined value_] and [*selection*: _FNMR, FRR_] not exceeding [*assignment*: _defined value_].
+*FIA_MBV_EXT.1.2*:: The TSF shall provide a biometric verification mechanism with the [*selection*: _FMR, FAR_] not exceeding [*assignment*: _defined value_] and [*selection*: _FNMR, FRR_] not exceeding [*assignment*: _defined value_].
 
 *Application Note {counter:remark_count}*:: If the TOE support multiple modalities, ST author may iterate the SFR to define different error rates for each modality.
 
@@ -430,56 +410,46 @@ For consistency in language throughout this document, referring to a “lower”
 
 . Technical limitation
 +
-Although different modalities are available for the mobile biometric verification, all modalities may not achieve the same level of accuracy. For modalities that have different target of error rates, ST author may iterate the requirement to set appropriate error rates for each modality.
+Although different modalities are available for the biometric verification, all modalities may not achieve the same level of accuracy. For modalities that have different target of error rates, ST author may iterate the requirement to set appropriate error rates for each modality.
 
 . Number of test subjects required for the performance testing
 +
 Target error rates defined in SFR shall be evaluated based on <<SD>>. Normally the target error rates will directly influence the size of the test subject, the time and cost of the testing. <<SD>> describes how those error rates should be evaluated in an objective manner.
 
-==== FIA_MBV_EXT.2 Quality of biometric samples for mobile biometric verification [[FIA_MBV_EXT.2]]
+==== FIA_MBV_EXT.2 Quality of biometric samples for biometric verification [[FIA_MBV_EXT.2]]
 
 *FIA_MBV_EXT.2.1* The TSF shall only use samples of sufficient quality to verify the user.
 
 *Application Note {counter:remark_count}*:: ST author may refine “sufficient quality” to specify quality standards if the TOE follows such standard.
-
-==== FIA_MBV_EXT.3 Presentation attack detection for mobile biometric verification [[FIA_MBV_EXT.3]]
-
-*FIA_MBV_EXT.3.1* The TSF shall prevent use of artificial presentation attack instruments from being successfully verified.
-
-*Application Note {counter:remark_count}*:: This requirement is only applicable to mobile biometric verification. PAD for biometric enrolment is an optional requirement.
-
-*Application Note {counter:remark_count}*:: Artificial PAIs that the TOE shall prevent and relevant criteria for its security relevant error rates for each type of PAI is defined in <<SD>>.
 
 === Protection of the TSF (FPT)
 ==== FPT_BDP_EXT.1 Biometric data processing [[FPT_BDP_EXT.1]]
 
 *FPT_BDP_EXT.1.1* The TSF shall process any plaintext biometric data used to generate templates and perform sample matching within the security boundary of the secure execution environment.
 
-*Application Note {counter:remark_count}*:: The Consistency Rationale in the appropriate PP-Configuration explains how the TOE in cooperation with its environment shall protect biometric data in detail.
+*Application Note {counter:remark_count}*:: The Consistency Rationale in the <<PPC-MDF>> explains how the biometric system in cooperation with the mobile device shall protect biometric data in detail.
 
 ==== FPT_BDP_EXT.2 No Biometric data transmission [[FPT_BDP_EXT.2]]
 
 *FPT_BDP_EXT.2.1* The TSF shall not transmit any plaintext biometric data outside the security boundary of the secure execution environment.
 
-*Application Note {counter:remark_count}*:: The Consistency Rationale in the appropriate PP-Configuration explains how the TOE in cooperation with its environment shall protect biometric data in detail.
+*Application Note {counter:remark_count}*:: The Consistency Rationale in the <<PPC-MDF>> explains how the biometric system in cooperation with the mobile device shall protect biometric data in detail.
 
 ==== FPT_BDP_EXT.3 Biometric data storage [[FPT_BDP_EXT.3]]
 
 [[FPT_BDP_EXT.3.1]]*FPT_BDP_EXT.3.1* The TSF shall not store any plaintext biometric data outside the security boundary of the secure execution environment.
 
-*Application Note {counter:remark_count}*:: The Consistency Rationale in the appropriate PP-Configuration explains how the TOE in cooperation with its environment shall protect biometric data in detail.
+*Application Note {counter:remark_count}*:: The Consistency Rationale in the <<PPC-MDF>> explains how the biometric system in cooperation with the mobile device shall protect biometric data in detail.
 
 ==== FPT_PBT_EXT.1 Protection of biometric template [[FPT_PBT_EXT.1]]
 
 *FPT_PBT_EXT.1.1*:: The TSF shall protect the template [*selection*: _using a PIN as an additional factor, using a password as an additional factor_, [*assignment*: _other circumstances_]].
 
-*Application Note {counter:remark_count}*:: The Consistency Rationale in the appropriate PP-Configuration explains how the TOE in cooperation with its environment shall protect biometric data in detail.
+*Application Note {counter:remark_count}*:: The Consistency Rationale in the <<PPC-MDF>> explains how the biometric system in cooperation with the mobile device shall protect biometric data in detail.
 
 == Security Assurance Requirements
 
 This PP-Module does not define any additional assurance requirements above and beyond what is defined in the base PP that it extends. Application of the SARs to the TOE boundary described by both the claimed base and this PP-Module is sufficient to demonstrate that the claimed SFRs have been implemented correctly by the TOE.
-
-
 
 == Selection-Based Requirements
 
@@ -501,16 +471,22 @@ ST authors are free to choose none, some or all SFRs defined in this Section. Ju
 
 *FIA_MBE_EXT.3.1* The TSF shall prevent use of artificial presentation attack instruments from being successfully enrolled.
 
+==== FIA_MBV_EXT.3 Presentation attack detection for biometric verification [[FIA_MBV_EXT.3]]
+
+*FIA_MBV_EXT.3.1* The TSF shall prevent use of artificial presentation attack instruments from being successfully verified.
+
+*Application Note {counter:remark_count}*:: Artificial PAIs that the TOE shall prevent and relevant criteria for its security relevant error rates for each type of PAI is defined in <<SD>>.
+
 === User data protection (FDP)
 
 ==== FDP_RIP.2 Full residual information protection [[FDP_RIP.2]]
 
 *FDP_RIP.2.1* The TSF shall ensure that any previous information content of biometric data is made unavailable upon the [*selection*: _allocation of the resource to, deallocation of the resource from_] all objects.
 
-*Application Note {counter:remark_count}*:: The Consistency Rationale in the appropriate PP-Configuration explains how the TOE in cooperation with its environment shall protect biometric data in detail.
+*Application Note {counter:remark_count}*:: The Consistency Rationale in the <<PPC-MDF>> explains how the biometric system in cooperation with the mobile device shall protect biometric data in detail.
 
 == Extended Component Definitions
-This appendix contains the definitions for the extended requirements that are used in the PP-Module, including those used in <<Selection-Based Requirements>> and <<Optional Requirements>>. 
+This appendix contains the definitions for the extended requirements that are used in the PP-Module, including those used in <<Optional Requirements>>. 
 
 (Note: formatting conventions for selections and assignments in this Section are those in <<CC2>>.)
 
@@ -564,7 +540,7 @@ a)	the management of the TSF data (setting values for detecting artificial prese
 ===== Audit: FIA_MBE_EXT.1, FIA_MBE_EXT.2
 The following actions should be auditable if FAU_GEN Security audit data generation is included in the PP/ST:
 
-a)	Basic: Success or failure of the mobile biometric enrollment
+a)	Basic: Success or failure of the biometric enrollment
 
 ===== Audit: FIA_MBE_EXT.3
 The following actions should be auditable if FAU_GEN Security audit data generation is included in the PP/ST:
@@ -618,9 +594,9 @@ This component defines the requirements for the TSF to be able to verify a user,
  
 FIA_MBV_EXT.1 Biometric verification requires the TSF to verify a user.
 
-FIA_MBV_EXT.2 Quality of biometric samples for mobile biometric verification requires the TSF to use samples of sufficient quality.
+FIA_MBV_EXT.2 Quality of biometric samples for biometric verification requires the TSF to use samples of sufficient quality.
 
-FIA_MBV_EXT.3 Presentation attack detection for mobile biometric verification requires the TSF to prevent presentation attacks during the mobile biometric verification.
+FIA_MBV_EXT.3 Presentation attack detection for biometric verification requires the TSF to prevent presentation attacks during the biometric verification.
 
 ===== Management: FIA_MBV_EXT.1
 
@@ -641,7 +617,7 @@ a)	the management of the TSF data (setting values for detecting artificial prese
 ===== Audit: FIA_MBV_EXT.1, FIA_MBV_EXT.2
 The following actions should be auditable if FAU_GEN Security audit data generation is included in the PP/ST:
 
-a)	Basic: Success or failure of the mobile biometric verification
+a)	Basic: Success or failure of the biometric verification
 
 ===== Audit: FIA_MBV_EXT.3
 The following actions should be auditable if FAU_GEN Security audit data generation is included in the PP/ST:
@@ -654,11 +630,11 @@ Hierarchical to: No other components
 
 Dependencies: FIA_MBE_EXT.1 Biometric enrolment
 
-*FIA_MBV_EXT.1.1* The TSF shall provide a mobile biometric verification mechanism using [*selection:* _fingerprint, eye, face, voice, vein_, [*assignment:* _other modality_]].
+*FIA_MBV_EXT.1.1* The TSF shall provide a biometric verification mechanism using [*selection:* _fingerprint, eye, face, voice, vein_, [*assignment:* _other modality_]].
 
-*FIA_MBV_EXT.1.2* The TSF shall provide a mobile biometric verification mechanism with the [*selection:* _FMR, FAR_] not exceeding [*assignment:* _defined value_] and [*selection:* _FNMR, FRR_] not exceeding [*assignment:* _defined value_].
+*FIA_MBV_EXT.1.2* The TSF shall provide a biometric verification mechanism with the [*selection:* _FMR, FAR_] not exceeding [*assignment:* _defined value_] and [*selection:* _FNMR, FRR_] not exceeding [*assignment:* _defined value_].
 
-===== FIA_MBV_EXT.2 Quality of biometric samples for mobile biometric verification
+===== FIA_MBV_EXT.2 Quality of biometric samples for biometric verification
 Hierarchical to: No other components.
 
 Dependencies: 	
@@ -670,7 +646,7 @@ FIA_MBV_EXT.1 Biometric verification
 
 *FIA_MBV_EXT.2.1* The TSF shall only use samples of sufficient quality to verify the user.
 
-===== FIA_MBV_EXT.3 Presentation attack detection for mobile biometric verification
+===== FIA_MBV_EXT.3 Presentation attack detection for biometric verification
 Hierarchical to: No other components
 
 Dependencies: 

--- a/3_ProtectionProfile/PP config.adoc
+++ b/3_ProtectionProfile/PP config.adoc
@@ -224,7 +224,57 @@ In order to evaluate a TOE that claims conformance to this PP-Configuration, the
 Note that to fully evaluate the TOE, these SARs shall be applied to the entire TSF and not just the portions described by <<MDFPP>> where the SARs are defined.
 
 === Evaluation methods/activities references statement
-<<MDFPP>> and <<SD>> define Evaluation Activities for how to evaluate individual SFRs as they relate to the SARs for ASE_TSS.1, AGD_OPE.1, and ATE_IND.1. <<MDFPP>> and <<SD>> also provide Evaluation Activities for the SARs. In evaluating this PP-Configuration, the evaluator shall ensure that all Evaluation Activities for SFRs and SARs are evaluated as part of satisfying the required SARs.
+<<MDFPP>> and <<SD>> define Evaluation Activities for how to evaluate individual SFRs as they relate to the SARs for ASE_TSS.1, AGD_OPE.1, and ATE_IND.1. If optional requirement FDP_RIP.2 is selected in the <<BIOPP-Module>>, the Evaluation Activities for FCS_CKM_EXT.4 in <<MDFPP>> can be applied to FDP_RIP.2.
+
+<<BIOPP-Module>> does not define any SARs beyond those defined within <<MDFPP>> to which it can claim conformance. It is important to note that the TOE that is evaluated against <<BIOPP-Module>> is inherently evaluated against <<MDFPP>> as well. This means that EAs in Section 5.2 *Security Assurance Requirements* in <<MDFPP>> should also applied to <<BIOPP-Module>> with additional application notes or EAs defined in the following Sections.
+
+==== Class ASE: Security Target
+
+<<MDFPP>> doesn’t define any EAs and there is no additional EAs for <<BIOPP-Module>>.
+
+==== Class ADV: Development
+
+Same EA defined in <<MDFPP>> should also be applied to <<BIOPP-Module>>.
+
+==== Class AGD: Guidance Documentation
+
+The evaluator shall take the following additional application notes into account to perform EAs defined in <<MDFPP>>.
+
+===== Application note for EA of AGD_OPE.1
+
+<<BIOPP-Module>> defines the assumptions for the mobile device that is the operational environment of the biometric system. These assumptions are implicitly satisfied if the mobile device is successfully evaluated based on <<MDFPP>> and the operational guidance doesn’t need to describe the security measures to be followed in order to fulfil the security objectives for the operational environment derived from those assumptions.
+
+There is additional application note related to EAs for FIA_MBV_EXT.3 in <<Additional application notes for AGD Class for FIA_MBV_EXT.3>>. The evaluator shall also follow this note depending on the result of the penetration testing for PAD.
+
+===== Application note for EA of AGD_PRE.1
+
+[BIOPP-Module] supposes that the biometric system is fully integrated into the mobile device and the preparative procedures are unnecessary for [BIOPP-Module]. Therefore, AGD_PRE.1 deems satisfied for <<BIOPP-Module>>.
+
+==== Class ALC: Life-cycle Support
+
+The evaluator shall take the following additional application notes into account to perform EAs defined in <<MDFPP>> for <<BIOPP-Module>>. There is no application note for EA for ALC_CMS.1 and ALC_TSU_EXT.
+
+===== Application note for EA of ALC_CMC.1
+
+<<BIOPP-Module>> is intended to be used with <<MDFPP>> and reference for the mobile device can be used as the TOE (mobile device + biometric system) reference only if the reference for the mobile device also uniquely identifies the biometric system embedded in the mobile device.
+
+==== Class ATE: Tests
+
+The evaluator shall take the following additional application notes into account to perform EAs defined in <<MDFPP>> for <<BIOPP-Module>>.
+
+===== Application note for EA of ATE_IND.1
+
+Same EA should be applied to <<BIOPP-Module>> except optional requirement FIA_MBE_EXT.3 (**Presentation attack detection for biometric enrolment**) and FIA_MBV_EXT.3 (**Presentation attack detection for biometric verification**). The evaluator shall perform EAs defined in <<Evaluation Activities for PAD testing>> for FIA_MBE_EXT.3 and FIA_MBV_EXT.3.
+
+==== Class AVA: Vulnerability Assessment
+
+The evaluator shall take the following additional application notes into account to perform EAs defined in <<MDFPP>> for <<BIOPP-Module>>.
+
+===== Application note for EA of AVA_VAN.1
+
+Same EA should be applied to <<BIOPP-Module>> except optional requirement FIA_MBE_EXT.3 (**Presentation attack detection for biometric enrolment**) and FIA_MBV_EXT.3 (**Presentation attack detection for biometric verification**). The evaluator shall perform EAs defined in <<Evaluation Activities for PAD testing>> for FIA_MBE_EXT.3 and FIA_MBV_EXT.3.
+
+In evaluating this PP-Configuration, the evaluator shall ensure that all Evaluation Activities for SFRs and SARs are evaluated as part of satisfying the required SARs.
 
 == Related Documents
 

--- a/3_ProtectionProfile/PP config.adoc
+++ b/3_ProtectionProfile/PP config.adoc
@@ -226,7 +226,7 @@ Note that to fully evaluate the TOE, these SARs shall be applied to the entire T
 === Evaluation methods/activities references statement
 <<MDFPP>> and <<SD>> define Evaluation Activities for how to evaluate individual SFRs as they relate to the SARs for ASE_TSS.1, AGD_OPE.1, and ATE_IND.1. <<MDFPP>> and <<SD>> also provide Evaluation Activities for the SARs. In evaluating this PP-Configuration, the evaluator shall ensure that all Evaluation Activities for SFRs and SARs are evaluated as part of satisfying the required SARs.
 
-=== Related Documents
+== Related Documents
 
 **Common Criteria**footnote:[For details see http://www.commoncriteriaportal.org/]
 

--- a/3_ProtectionProfile/PP config.adoc
+++ b/3_ProtectionProfile/PP config.adoc
@@ -2,55 +2,48 @@
 :showtitle:
 :toc:
 :table-caption: Table
-:revnumber: 0.9
-:revdate: 2019-08-05
+:revnumber: 0.91
+:revdate: 2019-12-05
 
 == Acknowledgements
 
 This PP-Configuration was developed by the Biometrics Security international Technical Community (BIO-iTC) with representatives from industry, Government agencies, Common Criteria Test Laboratories, and members of academia.
 
 :sectnums:
+:sectnumlevels: 5
 
 == Introduction
 
-=== Overview
+The purpose of a PP-Configuration is to define a Target of Evaluation (TOE) that combines Protection Profiles (PPs) and PP-Modules for various technology types into a single configuration that can be evaluated as a whole. The scope includes the definition of the configuration of a mobile device that has biometric enrolment and verification capability. The TOE will be defined by a combination of the components described in <<PP-Configuration Components Statement>>.
 
-The purpose of a PP-Configuration is to define a Target of Evaluation (TOE) that combines Protection Profiles (PPs) and PP-Modules for various technology types into a single configuration that can be evaluated as a whole. The scope includes the definition of the configuration of a mobile device that has biometric enrolment and verification capability. The TOE will be defined by a combination of the components described in section 1.3.
-
-=== PP-Configuration Reference
+== PP-Configuration Reference
 
 This PP-Configuration is identified as follows:
 
-* PP-Configuration for Protection Profile for Mobile Device Fundamentals and collaborative PP-Module for Biometric enrolment and verification - for unlocking the device - version 0.8, May 01, 2019
-* As a shorthand reference, it can be identified as "PPC+MDF+BIO+01"
+* PP-Configuration for Protection Profile for Mobile Device Fundamentals and collaborative PP-Module for Biometric enrolment and verification - for unlocking the device - version 0.91, December 05, 2019
 
-=== PP-Configuration Components Statement
+== PP-Configuration Components Statement
 
 This PP-Configuration includes the following components:
 
-* base PP: Protection Profile for Mobile Device Fundamentals [MDFPP]
-* PP-Module: collaborative PP-Module for Biometric enrolment and verification - for unlocking the device - [BIOPP-Module].
+* base PP: Protection Profile for Mobile Device Fundamentals <<MDFPP>>
+* PP-Module: collaborative PP-Module for Biometric enrolment and verification - for unlocking the device - <<BIOPP-Module>>.
 
-== Consistency Rationale between this PP-Module and MDFPP
+== TOE overview
 
-=== Overview
-This section describes consistency rationale between this PP-Module and <<MDFPP>>.
+TOE type, major security features, expected usage of the TOE and non-TOE hardware, software and/or firmware required by the TOE is described in the <<MDFPP>> and <<BIOPP-Module>>.
 
-The TOE in this PP-Module is comprised of biometric capture sensors and firmware/software that provide functions described in PP-Module TOE design. The TOE is invoked by the mobile device as defined in the <<MDFPP>> (i.e. TOE environment) when user’s biometric characteristics is presented to the sensor. The TOE creates and stores the template or compares the features with the stored template and returns the verification outcome to the mobile device.
+== Consistency Rationale
 
-This PP-Module assumes that the mobile device satisfies SFRs defined in the <<MDFPP>> so that the TOE can work as specified in this PP-Module. The next section explains which SFRs in the <<MDFPP>> are directly relevant to the TOE security functionality.
+This section describes consistency rationale between <<MDFPP>> and <<BIOPP-Module>> to show that the unions of Security Problem Definition, objectives, and Security Functional Requirement(SFR)s defined in <<MDFPP>> and <<BIOPP-Module>> do not lead to a contradiction.
 
-=== Relevant SFRs in the MDFPP
-Relation between SFRs defined in this PP-Module and in the <<MDFPP>> is described below. *Bold SFRs* are those defined in this PP-Module and _italicized SFRs_ are those defined in <<MDFPP>>.
+=== Consistency of TOE Type
 
-=== Protection Profile for Mobile Device Fundamentals
+When the <<PP-Module>> is used to extend <<MDFPP>>, the TOE type for the overall TOE is still a generic mobile device. However, one of the functions of the device must be the ability for it to have biometric enrolment and verification capability. The TOE boundary is simply extended to include that functionality.
 
-==== Consistency of TOE Type
+=== Consistency of Security Problem Definition
 
-When this PP-Module is used to extend <<MDFPP>>, the TOE type for the overall TOE is still a generic mobile device. However, one of the functions of the device must be the ability for it to have biometric enrolment and verification capability. The TOE boundary is simply extended to include that functionality.
-
-==== Consistency of Security Problem Definition
-The threats, OSPs and assumptions defined by the PP-Module (see the Sections: Threats, Organizational Security Policies and Assumptions) are consistent with those defined in the <<MDFPP>> as follows:
+The threats, OSPs and assumptions defined by the <<BIOPP-Module>> (see the Sections: Threats, Organizational Security Policies and Assumptions) are consistent with those defined in the <<MDFPP>> as follows:
 
 .Consistency Rationale for threats and OSPs
 [cols="1,1",options="header"]
@@ -84,7 +77,7 @@ The threats, OSPs and assumptions defined by the PP-Module (see the Sections: Th
 
 |===
 
-==== Consistency of Objectives
+=== Consistency of Objectives
 
 The objectives for the biometric system and its operational environment are consistent with the <<MDFPP>> based on the following rationale:
 
@@ -118,87 +111,80 @@ The objectives for the biometric system and its operational environment are cons
 
 |===
 
-==== Consistency of Requirements
-This PP-Module identifies several SFRs from <<MDFPP>> that are needed to support biometric system functionality. The rationale for why this does not conflict with the claims defined by the <<MDFPP>> are described in Consistency Rationale between this PP-Module and MDFPP.
+=== Consistency of Requirements
 
-==== Password authentication
+The Biometric System (i.e. TSF in the <<BIOPP-Module>>) is comprised of biometric capture sensors and firmware/software that provide functions described in the <<BIOPP-Module>> TOE design. The Biometric System is invoked by the mobile device as defined in the <<MDFPP>> when user’s biometric characteristics is presented to the sensor. The Biometric System creates and stores the template or compares the features with the stored template and returns the verification outcome to the mobile device.
+
+The <<BIOPP-Module>> assumes that the mobile device satisfies SFRs defined in the <<MDFPP>> so that the Biometric System can work as specified in the <<BIOPP-Module>>. This section explains which SFRs in the <<MDFPP>> are directly relevant to the Biometric System security functionality.
+
+The following rationale identifies several SFRs from <<MDFPP>> that are needed to support Biometric System functionality and explains why the unions of SFRs in the <<MDFPP>> and <<BIOPP-Module>> do not lead to a contradiction.
+
+==== Relation among SFRs/OEs in the <<MDFPP>> and <<BIOPP-Module>>
+Relation between SFRs defined in the <<MDFPP>> and SFRs and OEs in the <<BIOPP-Module>> is described below for each security functionality. *Bold SFRs* are those SFRs defined in the <<BIOPP-Module>> for the Biometric System and _italicized SFRs_ are those defined in <<MDFPP>> for the mobile device.
+
+===== Password authentication
 Mobile device shall implement the Password Authentication Factor as required by the _FIA_UAU.5.1._ This password authentication is used as an alternative authentication mechanism when the user is rejected by the biometric verification.
 
-This PP-Module assumes that above requirements are satisfied by the mobile device as defined in OE.Alternative.
+The <<BIOPP-Module>> assumes that above requirements are satisfied by the mobile device as defined in OE.Alternative.
 
-==== Invocation of the TOE
-For any modality selected in _FIA_UAU.5.1_, mobile device shall invoke the TOE to unlock the device under the condition specified in _FIA_UAU.6.1(2)_. Mobile device shall also authenticate the user following the rule specified in _FIA_UAU.5.2_.
+===== Invocation of the Biometric System
+For any modality selected in _FIA_UAU.5.1_, mobile device shall invoke the Biometric System to unlock the device under the condition specified in _FIA_UAU.6.1(2)_. Mobile device shall also authenticate the user following the rule specified in _FIA_UAU.5.2_.
 
-This PP-Module assumes that above requirements are satisfied by the mobile device as defined in OE.Authentication.
+The <<BIOPP-Module>> assumes that above requirements are satisfied by the mobile device as defined in OE.Authentication.
 
-The TOE shall implement a biometric verification mechanism that satisfies SFRs defined in this PP-Module. This means that same modality shall be selected in *FIA_MBV_EXT.1.1*, and relevant criteria and its error rate shall be specified in *FIA_MBV_EXT.1.2*. If multiple modalities are selected in _FIA_UAU.5.1_, *FIA_MBV_EXT.1* shall be iterated for each modality. The TOE shall also enrol all modalities selected as specified in *FIA_MBE.EXT.1*, assure the quality of samples and templates as specified in *FIA_MBV.EXT.2* and *FIA_MBE.EXT.2* and prevent use of artificial presentation attack instruments during the biometric verification as specified in *FIA_MBV.EXT.3*. The TOE may also prevent use of artificial presentation attack instruments during the biometric enrolment as specified in *FIA_MBV.EXT.3*.
+The Biometric System shall implement a biometric verification mechanism that satisfies SFRs defined in the <<BIOPP-Module>>. This means that same modality shall be selected in *FIA_MBV_EXT.1.1*, and relevant criteria and its error rate shall be specified in *FIA_MBV_EXT.1.2*. If multiple modalities are selected in _FIA_UAU.5.1_, *FIA_MBV_EXT.1* shall be iterated for each modality. The Biometric System shall also enrol all modalities selected as specified in *FIA_MBE.EXT.1*, to assure the quality of samples and templates as specified in *FIA_MBV.EXT.2* and *FIA_MBE.EXT.2*. The Biometric System may also prevent use of artificial presentation attack instruments during the biometric enrolment and verification as specified in *FIA_MBE.EXT.3* and *FIA_MBV.EXT.3*.
 
-All SFRs in bold are defined in Security Functional Requirements, Selection-Based Requirements and Optional Requirements in this PP-Module.
+All SFRs in bold are defined in Security Functional Requirements and Optional Requirements in the <<BIOPP-Module>>.
 
-==== Handling the verification outcome
-Mobile device shall take appropriate actions after receiving the verification outcome from the TOE as defined in _FIA_AFL_EXT.1_. 
+===== Handling the verification outcome
+Mobile device shall take appropriate actions after receiving the verification outcome from the Biometric System as defined in _FIA_AFL_EXT.1_. 
 
 _FIA_AFL_EXT.1_ defines rules regarding how the authentication factors interact in terms of unsuccessful authentication and actions mobile device shall take when number of unsuccessful authentication attempts surpass the pre-defined number. Mobile device also shall apply authentication throttling after failed biometric verification, as required by _FIA_TRT_EXT.1.1_.
 
-This PP-Module assumes that above requirements are satisfied by the mobile device as defined in OE.Authentication.
+The <<BIOPP-Module>> assumes that above requirements are satisfied by the mobile device as defined in OE.Authentication.
 
-==== Protection of the TOE and its biometric data
-Mobile device shall provide the secure execution environment (e.g. restricted operational environment) so that TOE can work securely. This secure execution environment guarantees code and data loaded inside to be protected with respect to confidentiality and integrity. This secure execution environment is out of scope of the TOE and shall be provided by the mobile device and evaluated based on <<MDFPP>>. However, ST author shall explain how such secure execution environment is provided by the mobile device for the TOE, as required by <<SD>>. Mobile device shall also keep secret any sensitive information regarding the biometric when mobile device receives the verification outcome from the TOE, as required by _FIA_UAU.7.1_, and provide cryptographic support to encrypt or decrypt biometric data as required by _FCS class_.
+===== Protection of the Biometric System and its biometric data
+Mobile device shall provide the secure execution environment (e.g. restricted operational environment) so that Biometric System can work securely. This secure execution environment guarantees code and data loaded inside to be protected with respect to confidentiality and integrity. This secure execution environment is out of scope of the Biometric System defined in the <<BIOPP-Module>> and shall be provided by the mobile device and evaluated based on <<MDFPP>>. However, ST author shall explain how such secure execution environment is provided by the mobile device for the Biometric System, as required by <<SD>>. Mobile device shall also keep secret any sensitive information regarding the biometric when mobile device receives the verification outcome from the Biometric System, as required by _FIA_UAU.7.1_, and provide cryptographic support to encrypt or decrypt biometric data as required by _FCS class_.
 
-This PP-Module assumes that above requirements are satisfied by the mobile device as defined in OE.Protection.
+The <<BIOPP-Module>> assumes that above requirements are satisfied by the mobile device as defined in OE.Protection.
 
-However, the TOE shall use this secure execution environment correctly to protect biometric data and satisfy the following requirements:
+However, the Biometric System shall use this secure execution environment correctly to protect biometric data and satisfy the following requirements:
 
-* The TOE shall process any plaintext biometric data (e.g. capturing biometric characteristic, creating samples, features and templates) for biometric enrolment and verification within the boundary of the secure execution environment. This implies that:
-** Any part of the TOE that processes plaintext biometric data shall be within the boundary of the secure execution environment. For example, the biometric capture sensor shall be configured to be within the boundary of the secure execution environment, so that only the secure execution environment can access to the sensor and the data captured. Any software modules that process plaintext biometric data shall run within the boundary of the secure execution environment.
-** Plaintext biometric data shall never be accessible from outside the secure execution environment, and any entities outside the secure execution environment can only access the result of process of biometric data (e.g. success or failure of biometric verification) through the interface provided by the TOE.
+* The Biometric System shall process any plaintext biometric data (e.g. capturing biometric characteristic, creating samples, features and templates) for biometric enrolment and verification within the boundary of the secure execution environment. This implies that:
+** Any part of the Biometric System that processes plaintext biometric data shall be within the boundary of the secure execution environment. For example, the biometric capture sensor shall be configured to be within the boundary of the secure execution environment, so that only the secure execution environment can access to the sensor and the data captured. Any software modules that process plaintext biometric data shall run within the boundary of the secure execution environment.
+** Plaintext biometric data shall never be accessible from outside the secure execution environment, and any entities outside the secure execution environment can only access the result of process of biometric data (e.g. success or failure of biometric verification) through the interface provided by the Biometric System.
 
-* The TOE shall not transmit any plaintext biometric data outside of the secure execution environment.
+* The Biometric System shall not transmit any plaintext biometric data outside of the secure execution environment.
 
-If the TOE stores the part of biometric data outside the secure execution environment, the TOE shall protect such data so that any entities running outside the secure execution environment can’t get access to any plaintext biometric data. ST author shall explain what biometric data resides outside the secure execution environment as required by <<SD>> and if no data resides outside the environment, requirements below is implicitly satisfied.
+If the Biometric System stores the part of biometric data outside the secure execution environment, the Biometric System shall protect such data so that any entities running outside the secure execution environment can’t get access to any plaintext biometric data. ST author shall explain what biometric data resides outside the secure execution environment as required by <<SD>> and if no data resides outside the environment, requirements below is implicitly satisfied.
 
-* The TOE shall not store any plaintext biometric data outside the secure execution environment. As described in Section TOE design, the TOE can store templates in the enrolment database. The TOE shall encrypt templates using cryptographic service provided by the mobile device within the secure execution environment before storing them in the database, even if the mobile device storage itself is encrypted by the mobile device.
-* The TOE may override encrypted biometric data in the storage when no longer needed. For example, the TOE may override encrypted template when it is revoked. This is an optional requirement.
+* The Biometric System shall not store any plaintext biometric data outside the secure execution environment. As described in the <<BIOPP-Module>> Section TOE design, the Biometric System can store templates in the enrolment database. The Biometric System shall encrypt templates using cryptographic service provided by the mobile device within the secure execution environment before storing them in the database, even if the mobile device storage itself is encrypted by the mobile device.
+* The Biometric System may override encrypted biometric data in the storage when no longer needed. For example, the Biometric System may override encrypted template when it is revoked. This is an optional requirement.
 
-The TOE shall also protect templates so that only the user of the mobile device can access them. This means that the TOE shall only allow authenticated user by the Password Authentication Factor to access (e.g. add or revoke) the template.
+The Biometric System shall also protect templates so that only the user of the mobile device can access them. This means that the Biometric System shall only allow authenticated user by the Password Authentication Factor to access (e.g. add or revoke) the template.
 
-* The TOE shall control access to, including adding or revoking, the templates.
+* The Biometric System shall control access to, including adding or revoking, the templates.
 
-The above requirements are defined as *FPT_PBT_EXT.1*, *FPT_BDP_EXT.1*, *FPT_BDP_EXT.2* and *FPT_PBT_EXT.3* in Security Functional Requirements and *FDP_RIP.2* in Optional Requirements in this PP-Module.
+The above requirements are defined as *FPT_PBT_EXT.1*, *FPT_BDP_EXT.1*, *FPT_BDP_EXT.2* and *FPT_PBT_EXT.3* in Security Functional Requirements and *FDP_RIP.2* in Optional Requirements in the <<BIOPP-Module>>.
 
-==== Management of the TOE configuration
+===== Management of the Biometric System configuration
 Mobile device shall enable/disable the BAF as required by _FMT_SMF_EXT.1 (Management function 23)_, and revoke the BAF as _FMT_SMF_EXT.1 (Management Function 46)_. Any change to the BAF (e.g. adding or revoking templates) requires re-authentication via the Password Authentication Factor as required by _FIA_UAU.6.1(1)_.
 
-This PP-Module assumes that above requirements are satisfied by the TOE environment as defined in OE.Protection.
+The <<BIOPP-Module>> assumes that above requirements are satisfied by the TOE environment as defined in OE.Protection.
 
+== Conformance claim and conformance statement
 
-== Conformance Claims
+=== Common Criteria Conformance claim
 
-=== Common Criteria Conformance
+This PP-Configuration, <<MDFPP>> and <<BIOPP-Module>> are conformant to Common Criteria Version 3.1, Revision 5.
 
-*Conformance Statement*
+=== The conformance type
 
-To be conformant to this PP-Configuration, an ST must demonstrate Exact Conformance, a subset of Strict Conformance as defined in [MDFPP].
+To be conformant to this PP-Configuration, an ST must demonstrate Exact Conformance.
 
-The ST must include all components in the base PP that are:
+=== The Assurance package conformance claim
 
-* Unconditional (which are always required)
-* Selection-based (which are required when certain selections are chosen in the unconditional requirements)
-
-and may include components that are
-
-* Optional
-* Objective.
-
-The same conditions apply to [BIOPP-Module] that is included as part of this PP-Configuration.
-
-*CC Conformance Claims*
-
-This PP-Configuration, [MDFPP] and [BIOPP-Module] are conformant to Common Criteria Version 3.1, Revision 5.
-
-=== SAR Statement
-
-In order to evaluate a TOE that claims conformance to this PP-Configuration, the evaluator shall evaluate the TOE against the following SARs that are defined in the [MDFPP]:
+In order to evaluate a TOE that claims conformance to this PP-Configuration, the evaluator shall evaluate the TOE against the following SARs that are defined in the <<MDFPP>>:
 
 [cols=",",options="header",]
 .Assurance Components
@@ -235,10 +221,10 @@ In order to evaluate a TOE that claims conformance to this PP-Configuration, the
 
 |===
 
+Note that to fully evaluate the TOE, these SARs shall be applied to the entire TSF and not just the portions described by <<MDFPP>> where the SARs are defined.
 
-Note that to fully evaluate the TOE, these SARs shall be applied to the entire TSF and not just the portions described by [MDFPP] where the SARs are defined.
-
-In addition to this, both [MDFPP] and [BIOPP-Module] define "Evaluation Activities" for how to evaluate individual SFRs as they relate to the SARs for ASE_TSS.1, AGD_OPE.1, and ATE_IND.1. [MDFPP] and [BIOPP-Module] also provide Evaluation Activities for the SARs. In evaluating this PP-Configuration, the evaluator shall ensure that all Evaluation Activities for SFRs and SARs are evaluated as part of satisfying the required SARs.
+=== Evaluation methods/activities references statement
+<<MDFPP>> and <<SD>> define Evaluation Activities for how to evaluate individual SFRs as they relate to the SARs for ASE_TSS.1, AGD_OPE.1, and ATE_IND.1. <<MDFPP>> and <<SD>> also provide Evaluation Activities for the SARs. In evaluating this PP-Configuration, the evaluator shall ensure that all Evaluation Activities for SFRs and SARs are evaluated as part of satisfying the required SARs.
 
 === Related Documents
 
@@ -271,14 +257,14 @@ Version 0.5, May 2017.
 |Protection Profile for Mobile Device Fundamentals, Version:3.3
 
 |[#BIOPP-Module]#[BIOPP-Module]# 
-|collaborative PP-Module for Biometric enrolment and verification - for unlocking the device -, August 5, 2019, Version 0.9
+|collaborative PP-Module for Biometric enrolment and verification - for unlocking the device -, December 5, 2019, Version 0.91
 
 |[#SD]#[SD]#
-|Supporting Document Mandatory Technical Document: Evaluation Activities for collaborative PP-Module for Biometric enrolment and verification - for unlocking the device -, August 5, 2019, Version 0.4
+|Supporting Document Mandatory Technical Document: Evaluation Activities for collaborative PP-Module for Biometric enrolment and verification - for unlocking the device -, December 05, 2019, Version 0.5
 
 |===
 
-=== Revision History
+= Revision History
 
 [cols=",,",options="header",]
 |===
@@ -290,4 +276,8 @@ Version 0.5, May 2017.
 |0.9
 |August 5, 2019
 |Update from Puiblic Review Draft 1
+
+|0.91
+|December 5, 2019
+|Update to make PAD optional
 |===

--- a/4_Methodology/BS_SD.adoc
+++ b/4_Methodology/BS_SD.adoc
@@ -5,8 +5,8 @@
 :table-caption: Table
 :imagesdir: images
 :icons: font
-:revnumber: 0.4
-:revdate: 2019-08-05
+:revnumber: 0.5
+:revdate: 2019-12-05
 :xrefstyle: full
 
 == Foreword
@@ -42,8 +42,12 @@ Biometric Security international Technical Community (BIO-iTC)
 |Third release for internal review
 
 |0.4
-August 5, 2019
+|August 5, 2019
 |Updates based on Public Review Draft 1 comments
+
+|0.5
+|December 5, 2019
+|Updates to make PAD optional
 |===
 
 === General Purpose
@@ -52,7 +56,7 @@ See section 1.1.
 
 === Field of special use
 
-This Supporting Document applies to the evaluation of TOEs claiming conformance with the collaborative PP-Module for Biometric enrolment and verification - for unlocking the device - [BIOPP-Module].
+This Supporting Document applies to the evaluation of TOEs claiming conformance with the collaborative PP-Module for Biometric enrolment and verification - for unlocking the device - <<BIOPP-Module>>.
 
 === Acknowledgements
 
@@ -65,16 +69,16 @@ This Supporting Document was developed by the Biometric Security international T
 
 === Technology Area and Scope of Supporting Document
 
-This Supporting Document (SD) defines the Evaluation Activities (EAs) associated with the collaborative PP-Module for Biometric enrolment and verification - for unlocking the device - [BIOPP-Module] that is intended for use with the following base PP: +
+This Supporting Document (SD) defines the Evaluation Activities (EAs) associated with the collaborative PP-Module for Biometric enrolment and verification - for unlocking the device - <<BIOPP-Module>> that is intended for use with the following base PP: +
 
 
-*Protection Profile for Mobile Device Fundamentals ([MDFPP])*
+*Protection Profile for Mobile Device Fundamentals (<<MDFPP>>)*
 
-This SD is mandatory for evaluations of TOEs that claim conformance to [BIOPP-Module].
+This SD is mandatory for evaluations of TOEs that claim conformance to <<BIOPP-Module>>.
 
-The Biometric Security technical area has a number of specialised aspects, such as those relating to the biometric enrolment and verification, and to the particular ways in which the TOE needs to be assessed across a range of different Presentation Attack Instruments (PAI). This degree of specialisation, and the associations between individual SFRs in [BIOPP-Module], make it important for both efficiency and effectiveness that EAs are given more specific interpretations than those found in the generic CEM activities.
+The Biometric Security technical area has a number of specialised aspects, such as those relating to the biometric enrolment and verification, and to the particular ways in which the TOE optionally needs to be assessed across a range of different Presentation Attack Instruments (PAI). This degree of specialisation, and the associations between individual SFRs in <<BIOPP-Module>>, make it important for both efficiency and effectiveness that EAs are given more specific interpretations than those found in the generic CEM activities.
 
-Although EAs are defined mainly for the evaluator to follow, the definitions in this SD aim to provide a common understanding for developers, evaluators and users as to what aspects of the TOE are tested in an evaluation against [BIOPP-Module], and to what depth the testing is carried out. This common understanding in turn contributes to the goal of ensuring that evaluations against [BIOPP-Module] achieve comparable, transparent and repeatable results. In general, the definition of EAs will also help developers to prepare for evaluation by identifying specific requirements for their TOE. The specific requirements in EAs may in some cases clarify the meaning of SFRs, and may identify particular requirements for the content of Security Targets (STs) (especially the TOE Summary Specification (TSS)), AGD guidance, and possibly supplementary information (e.g. for biometric performance testing – see <<Developer’s performance test document and its assessment strategy>>).
+Although EAs are defined mainly for the evaluator to follow, the definitions in this SD aim to provide a common understanding for developers, evaluators and users as to what aspects of the TOE are tested in an evaluation against <<BIOPP-Module>>, and to what depth the testing is carried out. This common understanding in turn contributes to the goal of ensuring that evaluations against <<BIOPP-Module>> achieve comparable, transparent and repeatable results. In general, the definition of EAs will also help developers to prepare for evaluation by identifying specific requirements for their TOE. The specific requirements in EAs may in some cases clarify the meaning of SFRs, and may identify particular requirements for the content of Security Targets (STs) (especially the TOE Summary Specification (TSS)), AGD guidance, and possibly supplementary information (e.g. for biometric performance testing – see <<Developer’s performance test document and its assessment strategy>>).
 
 === Structure of the Document
 
@@ -88,7 +92,7 @@ In general, if all EAs (for both SFRs and SARs) are successfully completed in an
 
 ==== Glossary
 
-For definitions of standard CC terminology see [CC1]. For definitions of biometrics and mobile device, see [BIOPP-Module] and [MDFPP].
+For definitions of standard CC terminology see <<CC1>>. For definitions of biometrics and mobile device, see <<BIOPP-Module>> and <<MDFPP>>.
 
 ==== Acronyms
 
@@ -165,7 +169,7 @@ EAs in this SD provide specific or more detailed guidance to evaluate the biomet
 
 This Section explains how EAs for SFRs are derived from the particular CEM work units identified in Assessment Strategy to show the consistency and compatibility between the CEM work units and EAs in this SD.
 
-Assessment Strategy for ASE_TSS requires the evaluator to examine that the TSS provides sufficient design descriptions and its verdicts will be associated with the CEM work unit ASE_TSS.1-1. Evaluator verdicts associated with the supplementary information will also be associated with ASE_TSS.1-1, since the requirement to provide such evidence is specified in ASE in [MDFPP] from which SARs of [BIOPP-Module] are inherited.
+Assessment Strategy for ASE_TSS requires the evaluator to examine that the TSS provides sufficient design descriptions and its verdicts will be associated with the CEM work unit ASE_TSS.1-1. Evaluator verdicts associated with the supplementary information will also be associated with ASE_TSS.1-1, since the requirement to provide such evidence is specified in ASE in <<MDFPP>> from which SARs of <<BIOPP-Module>> are inherited.
 
 Assessment Strategy for AGD_OPE/ADV_FSP requires the evaluator to examine that the AGD guidance provides sufficient information for the administrators/users as it pertains to SFRs, its verdicts will be associated with CEM work units ADV_FSP.1-7, AGD_OPE.1-4, and AGD_OPE.1-5.
 
@@ -177,7 +181,7 @@ Assessment Strategy for ATE_IND requires the evaluator to conduct testing that t
 
 ===== Objective of the EA
 
-The evaluator shall verify that the TOE enrols a user only after successful authentication of the user by his/her password. Security requirements for the password authentication are defined in [MDFPP] and out of scope of this EA.
+The evaluator shall verify that the TOE enrols a user only after successful authentication of the user by his/her password. Security requirements for the password authentication are defined in <<MDFPP>> and out of scope of this EA.
 
 ===== Dependency
 
@@ -318,7 +322,7 @@ The evaluator shall verify that the TOE implements the biometric verification me
 
 The evaluator shall solely rely on the supplementary information (developer’s performance test document) to achieve this objective following instruction defined in Assessment Strategy.
 
-[BIOPP-Module] assumes that the biometric verification is not used for the security sensitive services and the TOE operational environment also limits the maximum number of failed verification attempts in succession. Therefore, risk of zero-effort impostor attempts is low and the developer may not follow the statistical method (e.g. Rule of 3 or Rule of 30) to measure the biometric verification performance.
+<<BIOPP-Module>> assumes that the biometric verification is not used for the security sensitive services and the TOE operational environment also limits the maximum number of failed verification attempts in succession. Therefore, risk of zero-effort impostor attempts is low and the developer may not follow the statistical method (e.g. Rule of 3 or Rule of 30) to measure the biometric verification performance.
 
 ===== Dependency
 
@@ -431,49 +435,6 @@ The evaluator can pass this EA only if the evaluator confirms that:
 
 The evaluator shall report the summary of result of EA defined above, especially how the evaluator reaches the Pass/Fail judgement based on the Pass/Fail criteria.
 
-==== EA for FIA_MBV_EXT.3
-
-===== Objective of the EA
-
-The evaluator shall verify that the TOE prevents use of artificial Presentation Attack Instruments (PAI). This section defines EAs derived from ASE_TSS.1, AGD_OPE.1 and ADV_FSP.
-
-The main part of EA for FIA_MBV_EXT.3 is evaluator’s testing using artificial PAI. The <<Evaluation Activities for FIA_MBV_EXT.3>> defines EAs for ATE_IND.1 and AVA_VAN.1 in detail that the evaluator shall perform during the testing.
-
-===== Dependency
-
-The evaluator shall perform the EAs for FIA_MBE_EXT.1, FIA_MBE_EXT.2, FIA_MBV_EXT.1 and FIA_MBV_EXT.2 first to confirm the biometric enrolment and verification can be done correctly.
-
-===== Tool types required to perform the EA
-
-No tool is required for this EA.
-
-===== Required input from the developer or other entities
-
-Following input is required from the developer.
-
-[loweralpha]
-. TSS shall explain how the TOE meets FIA_MBV_EXT.3 at high level description. TSS may only states that the TOE implements PAD mechanism and may not disclose any information about the PAD mechanism itself in detail because such information is beyond the scope of assurance level claimed by [BIOPP-Module] and may also be exploited by attackers
-. AGD guidance may provide information about how the TOE reacts when artificial PAI is detected
-
-===== Assessment Strategy
-
-====== Strategy for ASE_TSS and AGD_OPE/ADV_FSP
-
-The evaluator shall examine the TSS and AGD guidance to check that the TSS or AGD guidance states that the TOE prevents the use of artificial PAI.
-
-Main part of EA is evaluator’s testing defined in <<Evaluation Activities for FIA_MBV_EXT.3>>. The evaluator should not require the detail design description of PAD from developer because it’s beyond the scope of assurance level claimed in [BIOPP-Module].
-
-===== Pass/Fail criteria
-
-The evaluator can pass this EA only if the evaluator confirms that:
-
-[loweralpha]
-. TSS or AGD guidance states that the TOE prevents the use of artificial PAI
-
-===== Requirements for reporting
-
-The evaluator shall report the summary of result of EA defined above, especially how the evaluator reaches the Pass/Fail judgement based on the Pass/Fail criteria.
-
 === Protection of the TSF (FPT)
 
 ==== EA for FPT_BDP_EXT.1
@@ -482,7 +443,7 @@ The evaluator shall report the summary of result of EA defined above, especially
 
 [BIOPP-Module] assumes that the mobile device provides the Secure Execution Environment (SEE), an operating environment separate from the main mobile device operating system. Access to the SEE is highly restricted and may be made available through special processor modes, separate security processors or a combination to provide this separation.
 
-Evaluation of this SEE is out of scope of [BIOPP-Module] and the evaluator doesn’t need to evaluate this environment itself. However, the evaluator shall examine that the TOE processes any plaintext biometric data within the security boundary of the SEE. The SEE is responsible for preventing any entities outside the environment from accessing plaintext biometric data.
+Evaluation of this SEE is out of scope of <<BIOPP-Module>> and the evaluator doesn’t need to evaluate this environment itself. However, the evaluator shall examine that the TOE processes any plaintext biometric data within the security boundary of the SEE. The SEE is responsible for preventing any entities outside the environment from accessing plaintext biometric data.
 
 FPT_BDP_EXT.1 applies to plaintext biometric data being processed during biometric enrolment and verification. Protection of transmitted and stored biometric data is out of scope of this EA and covered by FPT_BDP_EXT.2 and FPT_BDP_EXT.3 respectively.
 
@@ -505,7 +466,7 @@ Following input is required from the developer.
 
 ====== Strategy for ASE_TSS
 
-As depicted in Figure 1 of [BIOPP-Module], biometric characteristics is captured by biometric capture sensor and then sent to the processors in mobile device for signal processing, PAD and comparison and return the decision outcome. This is a typical process flow of biometric verification; however, biometric capture sensor may do the all tasks within the sensor. In either case, all TSF modules (i.e. biometric capture sensor and any software running in biometric capture sensor and mobile device processors) that process plaintext biometric data must be separated from any entities outside the SEE. Any plaintext biometric data must not be accessible from any entities outside the SEE.
+As depicted in Figure 1 of <<BIOPP-Module>>, biometric characteristics is captured by biometric capture sensor and then sent to the processors in mobile device for signal processing, PAD and comparison and return the decision outcome. This is a typical process flow of biometric verification; however, biometric capture sensor may do the all tasks within the sensor. In either case, all TSF modules (i.e. biometric capture sensor and any software running in biometric capture sensor and mobile device processors) that process plaintext biometric data must be separated from any entities outside the SEE. Any plaintext biometric data must not be accessible from any entities outside the SEE.
 
 In any cases, the evaluator shall examine the TSS to confirm that;
 
@@ -569,7 +530,7 @@ If the TOE transmits biometric data, the evaluator shall examine that the activi
 . The TOE never transmits plaintext biometric data to outside the SEE. This means;
 +
 [arabic]
-.. The TOE encrypts plaintext biometric data to be transmitted using the cryptographic functions evaluated based on [MDFPP] within the SEE
+.. The TOE encrypts plaintext biometric data to be transmitted using the cryptographic functions evaluated based on <<MDFPP>> within the SEE
 .. If the TOE stores the encrypted biometric data outside the SEE for transmission, the TOE deletes such data after the transmission
 .. If the TOE displays the plaintext biometric data to the user to seek approval for transmission, such process is performed within the SEE
 
@@ -619,7 +580,7 @@ The evaluator shall examine the TSS to understand the activities that happen on 
 [loweralpha]
 . The TSS lists type of biometric data that the TOE stores in non-volatile memory outside the SEE
 . The TOE encrypts all plaintext biometric data listed in the TSS within the SEE before storing it in the non-volatile memory
-. The TOE uses cryptographic functions evaluated based on [MDFPP] to encrypt the data
+. The TOE uses cryptographic functions evaluated based on <<MDFPP>> to encrypt the data
 
 ====== Strategy for ATE_IND
 
@@ -627,12 +588,12 @@ The evaluator shall perform the following test to verify that the TOE encrypts p
 
 The following test steps require the developer to provide access to a test platform that provides the evaluator with tools that are typically not found on factory products.
 
-. The evaluator shall check that all cryptographic algorithms listed in “file list/format and cryptographic algorithm” are successfully evaluated based on [MDFPP]
+. The evaluator shall check that all cryptographic algorithms listed in “file list/format and cryptographic algorithm” are successfully evaluated based on <<MDFPP>>
 . The evaluator shall load an app onto the mobile device. This app shall attempt to traverse over all file systems and report any newly created files
 . The evaluator shall perform biometric enrolment and verification and run the app to list new files
 . The evaluator shall compare files reported by the app and ones listed in “file list/format and cryptographic algorithm”
 . If evaluator finds newly created files not listed in “file list/format and cryptographic algorithm”, the evaluator shall confirm that those files don’t include plaintext biometric data with the support from developer
-. For all files listed in “file list/format and cryptographic algorithm”, the evaluator shall display the contents of files and check that the files are encrypted. The evaluator can assume that encryption is done correctly because the TOE uses cryptographic algorithms evaluated based on [MDFPP]. The evaluator shall compare the content of files to the format defined in “file list/format and cryptographic algorithm” to check that the files don’t follow the defined format to implicitly assume files are encrypted.
+. For all files listed in “file list/format and cryptographic algorithm”, the evaluator shall display the contents of files and check that the files are encrypted. The evaluator can assume that encryption is done correctly because the TOE uses cryptographic algorithms evaluated based on <<MDFPP>>. The evaluator shall compare the content of files to the format defined in “file list/format and cryptographic algorithm” to check that the files don’t follow the defined format to implicitly assume files are encrypted.
 
 ===== Pass/Fail criteria
 
@@ -695,17 +656,23 @@ The evaluator shall report the summary of result of EA defined above, especially
 
 == Evaluation Activities for Selection-Based Requirements 
 
+The <<BIOPP-Module>> does not contain any selection-based requirements.
+
+== Evaluation Activities for Optional Requirements 
+
 === Identification and Authentication (FIA)
 
-==== EA for FIA_HYB_EXT.1
+==== EA for FIA_MBE_EXT.3
 
 ===== Objective of the EA
 
-A hybrid authentication mechanism is one where a user has to submit a combination of biometric sample and PIN or password with both to pass and without the user being made aware of which factor failed, if either fails. The evaluator shall verify that the TOE use only selected modality for this hybrid authentication.
+The evaluator shall verify that the TOE prevents use of artificial Presentation Attack Instruments (PAI) during biometric enrolment. This section defines EAs derived from ASE_TSS.1, AGD_OPE.1 and ADV_FSP.1.
+
+The main part of EA for FIA_MBE_EXT.3 is evaluator’s testing using artificial PAI. The <<Evaluation Activities for FIA_MBV_EXT.3>> defines EAs for ATE_IND.1 and AVA_VAN.1 in detail that the evaluator shall perform during the testing during biometric verification. The evaluator shall follow the same EAs for evaluating presentation attack detection during biometric enrolment. 
 
 ===== Dependency
 
-The evaluator shall perform the EA for FIA_MBE_EXT.1 first to confirm the biometric enrolment can be done correctly.
+The evaluator shall perform the EAs for FIA_MBE_EXT.1 and FIA_MBE_EXT.2 first to confirm the biometric enrolment can be done correctly.
 
 ===== Tool types required to perform the EA
 
@@ -716,97 +683,126 @@ No tool is required for this EA.
 Following input is required from the developer.
 
 [loweralpha]
-. TSS shall explain how the TOE meets FIA_MBE_EXT.1 at high level description
-. AGD guidance shall describe how the hybrid authentication can be done
+. TSS shall explain how the TOE meets FIA_MBE_EXT.3 at high level description. TSS may only states that the TOE implements PAD mechanism and may not disclose any information about the PAD mechanism itself in detail because such information is beyond the scope of assurance level claimed by <<BIOPP-Module>> and may also be exploited by attackers
+. AGD guidance may provide information about how the TOE reacts when artificial PAI is detected
 
 ===== Assessment Strategy
 
 ====== Strategy for ASE_TSS and AGD_OPE/ADV_FSP
 
-The evaluator shall examine the TSS to understand how the TOE verify a user with his/her biometric characteristics and PIN or password. The evaluator shall also examine the AGD guidance about how the TOE supports a user to verify him/herself correctly and how the TOE behaves when hybrid authentication is succeeded or failed.
+The evaluator shall examine the TSS and AGD guidance to check that the TSS or AGD guidance states that the TOE prevents the use of artificial PAI during biometric enrolment.
 
-====== Strategy for ATE_IND
-
-The evaluator shall perform the following test steps to verify that the TOE protects the templates as specified in TSS and AGD guidance.
-
-. The evaluator shall configure and perform hybrid authentication
-. The evaluator shall check that the TOE can conduct hybrid authentication as specified, especially, when either factor is failed, the TOE doesn't reveal any information about which factor is failed
+Main part of EA is evaluator’s testing defined in <<Evaluation Activities for FIA_MBV_EXT.3>>. The evaluator should not require the detail design description of PAD from developer because it’s beyond the scope of assurance level claimed in <<BIOPP-Module>>.
 
 ===== Pass/Fail criteria
 
 The evaluator can pass this EA only if the evaluator confirms that:
 
 [loweralpha]
-. Information necessary to perform this EA is described in the TSS and AGD guidance
-. The TOE can conduct hybrid authentication using modality as specified by the ST author
+. TSS or AGD guidance states that the TOE prevents the use of artificial PAI during biometric enrolment
 
 ===== Requirements for reporting
 
 The evaluator shall report the summary of result of EA defined above, especially how the evaluator reaches the Pass/Fail judgement based on the Pass/Fail criteria.
 
-== Evaluation Activities for Optional Requirements 
+==== EA for FIA_MBV_EXT.3
 
-=== Identification and Authentication (FIA)
+===== Objective of the EA
 
-==== EA for FIA_MBE_EXT.3
+The evaluator shall verify that the TOE prevents use of artificial Presentation Attack Instruments (PAI) during biometric verification. This section defines EAs derived from ASE_TSS.1, AGD_OPE.1 and ADV_FSP.1.
 
-The evaluator shall refer the EA for FIA_MBV_EXT.3 to perform evaluation of this SFR.
+The main part of EA for FIA_MBV_EXT.3 is evaluator’s testing using artificial PAI. The <<Evaluation Activities for FIA_MBV_EXT.3>> defines EAs for ATE_IND.1 and AVA_VAN.1 in detail that the evaluator shall perform during the testing.
+
+===== Dependency
+
+The evaluator shall perform the EAs for FIA_MBE_EXT.1, FIA_MBE_EXT.2, FIA_MBV_EXT.1 and FIA_MBV_EXT.2 first to confirm the biometric enrolment and verification can be done correctly.
+
+===== Tool types required to perform the EA
+
+No tool is required for this EA.
+
+===== Required input from the developer or other entities
+
+Following input is required from the developer.
+
+[loweralpha]
+. TSS shall explain how the TOE meets FIA_MBV_EXT.3 at high level description. TSS may only states that the TOE implements PAD mechanism and may not disclose any information about the PAD mechanism itself in detail because such information is beyond the scope of assurance level claimed by <<BIOPP-Module>> and may also be exploited by attackers
+. AGD guidance may provide information about how the TOE reacts when artificial PAI is detected
+
+===== Assessment Strategy
+
+====== Strategy for ASE_TSS and AGD_OPE/ADV_FSP
+
+The evaluator shall examine the TSS and AGD guidance to check that the TSS or AGD guidance states that the TOE prevents the use of artificial PAI during biometric verification.
+
+Main part of EA is evaluator’s testing defined in <<Evaluation Activities for FIA_MBV_EXT.3>>. The evaluator should not require the detail design description of PAD from developer because it’s beyond the scope of assurance level claimed in <<BIOPP-Module>>.
+
+===== Pass/Fail criteria
+
+The evaluator can pass this EA only if the evaluator confirms that:
+
+[loweralpha]
+. TSS or AGD guidance states that the TOE prevents the use of artificial PAI
+
+===== Requirements for reporting
+
+The evaluator shall report the summary of result of EA defined above, especially how the evaluator reaches the Pass/Fail judgement based on the Pass/Fail criteria.
 
 === User data protection (FDP)
 
 ==== EA for FDP_RIP.2
 
-The evaluator shall refer the EA for FCS_CKM_EXT.4 in [MDFPP] to perform evaluation of this SFR.
+The evaluator shall refer the EA for FCS_CKM_EXT.4 in <<MDFPP>> to perform evaluation of this SFR.
 
 == Evaluation Activities for SARs
 
-[BIOPP-Module] does not define any SARs beyond those defined within the [MDFPP] to which it can claim conformance. It is important to note that the TOE that is evaluated against [BIOPP-Module] is inherently evaluated against [MDFPP] as well. This means that EAs in <<Class ADV: Development>> (Security Assurance Requirements) in [MDFPP] should also applied to [BIOPP-Module] with additional application notes or EAs defined in the following Sections.
+<<BIOPP-Module>> does not define any SARs beyond those defined within the <<MDFPP>> to which it can claim conformance. It is important to note that the TOE that is evaluated against <<BIOPP-Module>> is inherently evaluated against <<MDFPP>> as well. This means that EAs in <<Class ADV: Development>> (Security Assurance Requirements) in <<MDFPP>> should also applied to <<BIOPP-Module>> with additional application notes or EAs defined in the following Sections.
 
 === Class ASE: Security Target
 
-[MDFPP] doesn’t define any EAs and there is no additional EAs for [BIOPP-Module].
+<<MDFPP>> doesn’t define any EAs and there is no additional EAs for <<BIOPP-Module>>.
 
 === Class ADV: Development
 
-Same EA defined in [MDFPP] should also be applied to [BIOPP-Module].
+Same EA defined in <<MDFPP>> should also be applied to <<BIOPP-Module>>.
 
 === Class AGD: Guidance Documentation
 
-The evaluator shall take the following additional application notes into account to perform EAs defined in [MDFPP].
+The evaluator shall take the following additional application notes into account to perform EAs defined in <<MDFPP>>.
 
 ==== Application note for EA of AGD_OPE.1
 
-[BIOPP-Module] defines the assumptions for the mobile device that is the operational environment of the biometric system. These assumptions are implicitly satisfied if the mobile device is successfully evaluated based on [MDFPP] and the operational guidance doesn’t need to describe the security measures to be followed in order to fulfil the security objectives for the operational environment derived from those assumptions.
+<<BIOPP-Module>> defines the assumptions for the mobile device that is the operational environment of the biometric system. These assumptions are implicitly satisfied if the mobile device is successfully evaluated based on <<MDFPP>> and the operational guidance doesn’t need to describe the security measures to be followed in order to fulfil the security objectives for the operational environment derived from those assumptions.
 
 There is additional application note related to EAs for FIA_MBV_EXT.3 in <<Additional application notes for AGD Class for FIA_MBV_EXT.3>>. The evaluator shall also follow this note depending on the result of the penetration testing for PAD.
 
 ==== Application note for EA of AGD_PRE.1
 
-[BIOPP-Module] supposes that the biometric system is fully integrated into the mobile device and the preparative procedures are unnecessary for [BIOPP-Module]. Therefore, AGD_PRE.1 deems satisfied for [BIOPP-Module].
+[BIOPP-Module] supposes that the biometric system is fully integrated into the mobile device and the preparative procedures are unnecessary for [BIOPP-Module]. Therefore, AGD_PRE.1 deems satisfied for <<BIOPP-Module>>.
 
 === Class ALC: Life-cycle Support
 
-The evaluator shall take the following additional application notes into account to perform EAs defined in [MDFPP] for [BIOPP-Module]. There is no application note for EA for ALC_CMS.1 and ALC_TSU_EXT.
+The evaluator shall take the following additional application notes into account to perform EAs defined in <<MDFPP>> for <<BIOPP-Module>>. There is no application note for EA for ALC_CMS.1 and ALC_TSU_EXT.
 
 ==== Application note for EA of ALC_CMC.1
 
-[BIOPP-Module] is intended to be used with [MDFPP] and reference for the mobile device can be used as the TOE (mobile device + biometric system) reference only if the reference for the mobile device also uniquely identifies the biometric system embedded in the mobile device.
+<<BIOPP-Module>> is intended to be used with <<MDFPP>> and reference for the mobile device can be used as the TOE (mobile device + biometric system) reference only if the reference for the mobile device also uniquely identifies the biometric system embedded in the mobile device.
 
 === Class ATE: Tests
 
-The evaluator shall take the following additional application notes into account to perform EAs defined in [MDFPP] for [BIOPP-Module].
+The evaluator shall take the following additional application notes into account to perform EAs defined in <<MDFPP>> for <<BIOPP-Module>>.
 
 ==== Application note for EA of ATE_IND.1
 
-Same EA should be applied to [BIOPP-Module] except SFR FIA_MBV_EXT.3 (**Presentation attack detection for biometric verification**). The evaluator shall perform EAs defined in <<Evaluation Activities for FIA_MBV_EXT.3>> for FIA_MBV_EXT.3.
+Same EA should be applied to <<BIOPP-Module>> except SFR FIA_MBV_EXT.3 (**Presentation attack detection for biometric verification**). The evaluator shall perform EAs defined in <<Evaluation Activities for FIA_MBV_EXT.3>> for FIA_MBV_EXT.3.
 
 === Class AVA: Vulnerability Assessment
 
-The evaluator shall take the following additional application notes into account to perform EAs defined in [MDFPP] for [BIOPP-Module].
+The evaluator shall take the following additional application notes into account to perform EAs defined in <<MDFPP>> for <<BIOPP-Module>>.
 
 ==== Application note for EA of AVA_VAN.1
 
-Same EA should be applied to [BIOPP-Module] except SFR FIA_MBV_EXT.3 (**Presentation attack detection for biometric verification**). The evaluator shall perform EAs defined in <<Evaluation Activities for FIA_MBV_EXT.3>> for FIA_MBV_EXT.3.
+Same EA should be applied to <<BIOPP-Module>> except SFR FIA_MBV_EXT.3 (**Presentation attack detection for biometric verification**). The evaluator shall perform EAs defined in <<Evaluation Activities for FIA_MBV_EXT.3>> for FIA_MBV_EXT.3.
 
 == Evaluation Activities for FIA_MBV_EXT.3
 
@@ -818,49 +814,49 @@ The evaluator shall perform the following two types of EAs or testing to evaluat
 . EAs for ATE_IND.1 (Independent testing - conformance)
 . EAs for AVA_VAN.1 (Vulnerability survey)
 
-ATE_IND.1 requires the evaluator to demonstrate that the TOE operates in accordance with its design representations described in TSS or AGD guidance (As described in [MDFPP], a formal or complete specification of PAD interface is not required but the evaluator should examine interface information presented in the TSS and AGD guidance).
+ATE_IND.1 requires the evaluator to demonstrate that the TOE operates in accordance with its design representations described in TSS or AGD guidance (As described in <<MDFPP>>, a formal or complete specification of PAD interface is not required but the evaluator should examine interface information presented in the TSS and AGD guidance).
 
-However, [BIOPP-Module] doesn’t require such design representations about PAD (e.g. how the TOE checks the liveness of the object) in TSS or AGD because those information is beyond the scope of assurance level claimed by [BIOPP-Module]. Therefore, this SD doesn’t also require the evaluator to test the functional aspects of PAD based on those design representations.
+However, <<BIOPP-Module>> doesn’t require such design representations about PAD (e.g. how the TOE checks the liveness of the object) in TSS or AGD because those information is beyond the scope of assurance level claimed by [BIOPP-Module]. Therefore, this SD doesn’t also require the evaluator to test the functional aspects of PAD based on those design representations.
 
-Instead, this SD requires the evaluator to conduct ATE_IND.1 evaluation (i.e. independent testing) in black-box manner. However, difficulty of black-box testing for PAD, as described in [ISO30107-3], is that it’s very difficult to have a comprehensive model of all possible PAIs. Therefore, it may be possible that different evaluator could use a different set of PAIs and see different test results for the same TOE.
+Instead, this SD requires the evaluator to conduct ATE_IND.1 evaluation (i.e. independent testing) in black-box manner. However, difficulty of black-box testing for PAD, as described in <<ISO30107-3>>, is that it’s very difficult to have a comprehensive model of all possible PAIs. Therefore, it may be possible that different evaluator could use a different set of PAIs and see different test results for the same TOE.
 
-To solve this issue, the Biometric Security iTC (BIO-iTC) creates [Toolbox]. This [Toolbox] defines the common PAIs for PAD testing based on publicly available information (e.g. research papers), experiences and knowledge shared among the BIO-iTC members.
+To solve this issue, the Biometric Security iTC (BIO-iTC) creates <<Toolbox>>. This <<Toolbox>> defines the common PAIs for PAD testing based on publicly available information (e.g. research papers), experiences and knowledge shared among the BIO-iTC members.
 
-[Toolbox] includes a collection of test items for each biometric modality. Each test item describes the procedure to create PAIs and the method to present them to the TOE in sufficient detail to enable the test to be repeatable.
+<<Toolbox>> includes a collection of test items for each biometric modality. Each test item describes the procedure to create PAIs and the method to present them to the TOE in sufficient detail to enable the test to be repeatable.
 
-The same [Toolbox] can also be used for AVA_VAN.1 evaluation (i.e. penetration testing) because AVA_VAN.1 requires the evaluator to devise tests based on information available in the public domain. However, [Toolbox] should be used in a different manner for AVA_VAN.1 evaluation. The following section explains how [Toolbox] should be used in EAs for ATE_IND.1 and AVA_VAN.1.
+The same <<Toolbox>> can also be used for AVA_VAN.1 evaluation (i.e. penetration testing) because AVA_VAN.1 requires the evaluator to devise tests based on information available in the public domain. However, <<Toolbox>> should be used in a different manner for AVA_VAN.1 evaluation. The following section explains how <<Toolbox>> should be used in EAs for ATE_IND.1 and AVA_VAN.1.
 
 === EAs for ATE_IND.1 (Independent testing - conformance)
 
-==== Independent test activities using [Toolbox]
+==== Independent test activities using <<Toolbox>>
 
-As described in previous section, [Toolbox] defines test items to create a representative set of PAIs that the evaluator shall use for the testing. During ATE_IND.1 evaluation, the evaluator shall conduct all test items in [Toolbox] for the selected modalities without any change. The evaluator is not allowed to skip any test items in the [Toolbox] to maintain compatibility between different evaluations.
+As described in previous section, <<Toolbox>> defines test items to create a representative set of PAIs that the evaluator shall use for the testing. During ATE_IND.1 evaluation, the evaluator shall conduct all test items in <<Toolbox>> for the selected modalities without any change. The evaluator is not allowed to skip any test items in the <<Toolbox>> to maintain compatibility between different evaluations.
 
 During the independent testing, the evaluator may find PAIs that are incorrectly matched to the enrolled target user however, the evaluator may not be able to reliably reproduce a successful presentation attack.
 
-[Toolbox] defines the Pass/Fail criteria, maximum attack presentation match rate for PAIs. The evaluator shall follow the [Toolbox] criteria for the number of PAI presentations and confirm that the TOE’s match rate is below the specified criteria during the independent testing. The evaluator shall assign fail verdict to those TOE that doesn’t satisfy the criteria.
+[Toolbox] defines the Pass/Fail criteria, maximum attack presentation match rate for PAIs. The evaluator shall follow the <<Toolbox>> criteria for the number of PAI presentations and confirm that the TOE’s match rate is below the specified criteria during the independent testing. The evaluator shall assign fail verdict to those TOE that doesn’t satisfy the criteria.
 
 The PAIs that pass the criteria but show the higher attack presentation match rate will be tested again during the AVA_VAN.1 evaluation.
 
-[Toolbox] does not necessarily cover all biometric modalities. If the developer wants to evaluate modalities not currently included in [Toolbox], the developer and evaluator shall contact to the BIO-iTC to work together to extend [Toolbox]. Upon the BIO-iTC approval of this extension, the evaluator can proceed with PAD evaluation for new modality.
+<<Toolbox>> does not necessarily cover all biometric modalities. If the developer wants to evaluate modalities not currently included in <<Toolbox>>, the developer and evaluator shall contact to the BIO-iTC to work together to extend <<Toolbox>>. Upon the BIO-iTC approval of this extension, the evaluator can proceed with PAD evaluation for new modality.
 
 ==== Justification for EAs for ATE_IND.1
 
 The EAs presented in this section are derived from ATE_IND.1-3, ATE_IND.1-4 and ATE_IND.1-7 and their verdicts will be associated with those work units.
 
-[Toolbox] describes a test subset and test documentation that is sufficiently detailed to enable the tests to be reproducible (ATE_IND.1-3 and ATE_IND.1-4). [Toolbox] also defines Pass/Fail criteria that support evaluator’s decision (ATE_IND.1-7).
+<<Toolbox>> describes a test subset and test documentation that is sufficiently detailed to enable the tests to be reproducible (ATE_IND.1-3 and ATE_IND.1-4). <<Toolbox>> also defines Pass/Fail criteria that support evaluator’s decision (ATE_IND.1-7).
 
 === EA for AVA_VAN.1 (Vulnerability survey)
 
-==== Penetration test activities using [Toolbox]
+==== Penetration test activities using <<Toolbox>>
 
 This Section describes EAs for AVA_VAN.1 step by step following the order of AVA_VAN.1 CEM work units.
 
 ===== Search for new PAIs
 
-The evaluator shall search publicly available information that is published after the publication date of [Toolbox] to look for new PAI species. New PAI species are those PAIs that are out of scope of [Toolbox] and need to be made in the completely different way with the significantly different materials that are not covered by [Toolbox].
+The evaluator shall search publicly available information that is published after the publication date of <<Toolbox>> to look for new PAI species. New PAI species are those PAIs that are out of scope of <<Toolbox>> and need to be made in the completely different way with the significantly different materials that are not covered by <<Toolbox>>.
 
-Those new PAI species that can be made by slightly modifying test items in [Toolbox] are covered by <<No new PAIs found test plan>>.
+Those new PAI species that can be made by slightly modifying test items in <<Toolbox>> are covered by <<No new PAIs found test plan>>.
 
 ===== Identify candidate PAIs for testing
 
@@ -868,7 +864,7 @@ The evaluator shall perform EAs in <<No new PAIs found>> if there is no new PAI 
 
 ====== No new PAIs found
 
-If the evaluator can’t find such new PAI species, the evaluator doesn’t need to devise new test items in addition to those defined in [Toolbox] because the BIO-iTC develops test items based on all publicly available information published by the publication date of [Toolbox]. The BIO-iTC also verifies that test items cover all existing PAI species that are within the scope of Basic attack potential defined in <<Attack Potential and TOE resistance>>. Therefore, the evaluator doesn’t need to repeat this process.
+If the evaluator can’t find such new PAI species, the evaluator doesn’t need to devise new test items in addition to those defined in <<Toolbox>> because the BIO-iTC develops test items based on all publicly available information published by the publication date of <<Toolbox>>. The BIO-iTC also verifies that test items cover all existing PAI species that are within the scope of Basic attack potential defined in <<Attack Potential and TOE resistance>>. Therefore, the evaluator doesn’t need to repeat this process.
 
 ====== New PAIs found
 
@@ -882,10 +878,10 @@ For enhanced security that is easy to use, the TOE implements biometric verifica
 Attacker may use any tools or materials that are normally available at home and normal office environment such as laptop PC or office printer to attack the TOE. Attacker may also use any services (e.g. printing services to print a high-resolution photo of target users to create a face PAI) if such services are available at low cost.
 
 [loweralpha, start=2]
-. Assumptions in [BIOPP-Module]
+. Assumptions in <<BIOPP-Module>>
 +
 --
-[BIOPP-Module] defines *A.User* and evaluator shall assume that the mobile devices are configured securely by users. Especially evaluator shall make the following assumptions:
+<<BIOPP-Module>> defines *A.User* and evaluator shall assume that the mobile devices are configured securely by users. Especially evaluator shall make the following assumptions:
 
 [arabic]
 .. A user enrol him/herself following guidance provided by the TOE
@@ -893,7 +889,7 @@ Attacker may use any tools or materials that are normally available at home and 
 +
 For efficiency, the evaluator can increase the maximum number of unsuccessful biometric authentication attempts to conduct the testing. However, as the mobile device shall be evaluated in the evaluated configuration, any attack needs to succeed within the allowed number of biometric authentication attempts defined in the ST to be considered a successful attack.
 
-[BIOPP-Module] also defines *A.Protection* and evaluator shall assume that biometric data is adequately protected. Especially evaluator shall make the following assumptions:
+<<BIOPP-Module>> also defines *A.Protection* and evaluator shall assume that biometric data is adequately protected. Especially evaluator shall make the following assumptions:
 
 [arabic, start=1]
 .. Attacker can’t access to the result of PAD subsystem, so they can’t tune the PAIs based on the PAD score
@@ -920,7 +916,7 @@ The evaluator may recreate the PAIs selected for penetration testing to improve 
 [loweralpha]
 . Modify the creation process of PAIs
 +
-The evaluator may modify the process in [Toolbox] to improve the PAIs.
+The evaluator may modify the process in <<Toolbox>> to improve the PAIs.
 +
 For example, in case of finger or palm vein verification, the evaluator needs to capture the vein pattern from a target user using a NIR-camera and print it out to create the PAI (i.e. printed vein pattern). However, quality of the vein pattern may vary depending on configuration of tools (e.g. intensity of NIR light for NIR-camera) or type of materials (e.g. type of paper).
 +
@@ -929,7 +925,7 @@ During the penetration testing, the evaluator may change those various factors t
 However, the evaluator shall recreate the PAI at the similar cost and time as required for the original PAI to stay within the Basic attack potential.
 . Change test subjects
 +
-The evaluator may follow the same procedure in [Toolbox] to recreate PAIs, however, from different test subjects from ones used for the independent testing.
+The evaluator may follow the same procedure in <<Toolbox>> to recreate PAIs, however, from different test subjects from ones used for the independent testing.
 +
 For example, in case of finger or palm vein verification, men normally have thicker blood vessel than women. So, the evaluator may change the test subject who has thicker blood vessel to capture the clearer vein pattern.
 . Improve presentation method
@@ -940,9 +936,9 @@ For example, in case of finger or palm vein verification, quality of vein patter
 
 ====== New PAIs found test plan
 
-If the evaluator can find the new PAI species that can be used for the penetration testing, the evaluator shall produce the test item for those new PAI species and add them to [Toolbox]. The evaluator shall create those new test items at the same format and level of detail as existing ones in [Toolbox].
+If the evaluator can find the new PAI species that can be used for the penetration testing, the evaluator shall produce the test item for those new PAI species and add them to <<Toolbox>>. The evaluator shall create those new test items at the same format and level of detail as existing ones in <<Toolbox>>.
 
-The evaluator shall also inform the BIO-iTC for this update because the BIO-iTC is responsible for maintaining [Toolbox].
+The evaluator shall also inform the BIO-iTC for this update because the BIO-iTC is responsible for maintaining <<Toolbox>>.
 
 The evaluator shall also perform EAs in <<No new PAIs found test plan>> to produce the test plan based on the result of independent testing.
 
@@ -952,11 +948,11 @@ The evaluator shall conduct the penetration testing based on the test plan creat
 
 The evaluator shall select those PAIs that may succeed the attack at higher probability as described in <<Produce test plan>> for the penetration testing.
 
-However, the evaluator shall not spend more than one week for independent and penetration testing, considering the assurance level claimed by [BIOPP-Module].
+However, the evaluator shall not spend more than one week for independent and penetration testing, considering the assurance level claimed by <<BIOPP-Module>>.
 
 ===== Determine Pass/Fail of penetration testing
 
-The evaluator shall determine that the TOE, in its operational environment, is resistant to an attacker possessing a Basic attack potential. The evaluator shall make this determination based on guidance provided in  <<Pass/Fail criteria for EAs for FIA_MBV_EXT.3>> and maximum allowable error rates defined in [Toolbox].
+The evaluator shall determine that the TOE, in its operational environment, is resistant to an attacker possessing a Basic attack potential. The evaluator shall make this determination based on guidance provided in  <<Pass/Fail criteria for EAs for FIA_MBV_EXT.3>> and maximum allowable error rates defined in <<Toolbox>>.
 
 ==== Justification for EAs for AVA_VAN.1
 
@@ -976,11 +972,11 @@ The developer shall create the test document to report the result of performance
 
 The evaluator shall examine the test document following the Assessment Strategy defined in <<EA for FIA_MBV_EXT.1>> to verify that the developer’s performance test was done in an objective and repeatable manner to check the trustworthiness of the measured error rates.
 
-The requirements defined in this Section are created based on [ISO19795-1] and [ISO19795-2].
+The requirements defined in this Section are created based on <<ISO19795-1>> and <<ISO19795-2>>.
 
 === Requirements for the test document
 
-The developer shall provide the test document for CC evaluations that claim a conform to [BIOPP-Module]. This Section defines required content of the test document that is inputted to the EA for FIA_MBV_EXT.1.
+The developer shall provide the test document for CC evaluations that claim a conform to <<BIOPP-Module>>. This Section defines required content of the test document that is inputted to the EA for FIA_MBV_EXT.1.
 
 === Summary of contents
 
@@ -1004,7 +1000,7 @@ The developer shall provide the test document for CC evaluations that claim a co
 
 === Reporting items description
 
-This Section describes each item in <<ReportingItemsTable>> in detail. All items are created based on [ISO19795-1] and [ISO19795-2] however some of them are modified to adjust to the CC evaluation.
+This Section describes each item in <<ReportingItemsTable>> in detail. All items are created based on <<ISO19795-1>> and <<ISO19795-2>> however some of them are modified to adjust to the CC evaluation.
 
 ==== Overview of the performance testing
 
@@ -1018,7 +1014,7 @@ The test document shall report the following information to uniquely identify th
 [arabic]
 .. TOE reference
 +
-Information that uniquely identifes the TOE shall be reported. [BIOPP-Module] is intended to be used with [MDFPP] and reference for the mobile device can be used as the TOE reference only if the reference for the mobile device also uniquely identifies the biometric system embedded in the mobile device
+Information that uniquely identifes the TOE shall be reported. <<BIOPP-Module>> is intended to be used with <<MDFPP>> and reference for the mobile device can be used as the TOE reference only if the reference for the mobile device also uniquely identifies the biometric system embedded in the mobile device
 +
 Modification to the TOE for performance testing, if any, shall be reported (e.g. The TOE is modified to export biometric data for off-line testing). The rationale that such modification doesn’t affect the TOE performance shall also be provided. For example, the developer may claim that the performance is not affected because modified code isn’t executed during biometric verification or the developer may run regression test to verify that modification doesn’t change the result of verification (e.g. similarity score).
 .. TOE configuration
@@ -1078,9 +1074,9 @@ Test document shall specify a target application modelled in the test, such as b
 
 Test document shall also report influential factors that may influence performance, measures to control such factors and under what factors the performance testing was conducted.
 
-Influential factors can be determined by referring appropriate documents (e.g. [ISO19795-3]) or referring the product datasheet (e.g. operating temperature). These factors should be consistent with the target application.
+Influential factors can be determined by referring appropriate documents (e.g. <<ISO19795-3>>) or referring the product datasheet (e.g. operating temperature). These factors should be consistent with the target application.
 
-The following factors are examples of controlling factors for finger/hand vein verification. The developer shall define these factors properly, for example, based on [ISO19795-3]. Any information that are useful in the context of the used biometric modality shall be considered by the developer to determine the factors.
+The following factors are examples of controlling factors for finger/hand vein verification. The developer shall define these factors properly, for example, based on <<ISO19795-3>>. Any information that are useful in the context of the used biometric modality shall be considered by the developer to determine the factors.
 
 It’s recommended to control all influential factors appropriately because different error rates may be measured under different influential factors.
 
@@ -1179,7 +1175,7 @@ Suppose the mobile device provides both Password Authentication Factor and BAF a
 
 It may also be possible for user to enrol multiple body parts (e.g. index and thumb fingerprint) or single body part for biometric verification.
 
-However, it’s not possible to evaluate all these scenarios to measure the performance but the developer shall refer the ST that claims conformance to [MDFPP] to define the scenario.
+However, it’s not possible to evaluate all these scenarios to measure the performance but the developer shall refer the ST that claims conformance to <<MDFPP>> to define the scenario.
 
 For example, if the ST sets the maximum number of unsuccessful authentication attempts for mobile fingerprint verification to five, the developer shall assume that the attacker makes all five fingerprint unlock attempts in succession to try to unlock the mobile device.
 
@@ -1201,7 +1197,7 @@ The developer shall define the maximum number of samples per test subject to be 
 
 ==== Maximum number of transactions per test subject
 
-Only one transaction can be run by each test subject because the mobile device locks the biometric verification as required by [MDFPP] after the certain number of attempts are failed.
+Only one transaction can be run by each test subject because the mobile device locks the biometric verification as required by <<MDFPP>> after the certain number of attempts are failed.
 
 ==== Statistical certainty for FAR/FMR
 
@@ -1229,7 +1225,7 @@ If the developer specifies 0.01 % FMR and 1% FNMR in FIA_MBV_EXT.1, at least 30,
 
 === Calculating attack potential for generic biometric system
 
-Attack potential is a function of expertise, resources and motivation, as is written in [CEM]. [CEM] provides general guidance for calculating attack potential for all type of IT products and doesn’t take any specific characteristics of biometrics into account.
+Attack potential is a function of expertise, resources and motivation, as is written in <<CEM>>. <<CEM>> provides general guidance for calculating attack potential for all type of IT products and doesn’t take any specific characteristics of biometrics into account.
 
 This section introduces a method for calculating attack potential for generic biometric systems.
 
@@ -1255,7 +1251,7 @@ Exploitation consisting in applying scripts, it is expected that some factor val
 
 ==== Factors to be considered
 
-As in [CEM], the factors to be considered consist of *_Elapsed time_*, *_Expertise_*, *_Knowledge of the TOE_*, *_Window of opportunity_*, and *_Equipment_*. But *_Window of opportunity_* is divided into two subfactors *_Window of opportunity (Access to the TOE)_* and *_Window of opportunity (Access to biometric characteristics)_*.
+As in <<CEM>>, the factors to be considered consist of *_Elapsed time_*, *_Expertise_*, *_Knowledge of the TOE_*, *_Window of opportunity_*, and *_Equipment_*. But *_Window of opportunity_* is divided into two subfactors *_Window of opportunity (Access to the TOE)_* and *_Window of opportunity (Access to biometric characteristics)_*.
 
 *_Elapsed time_* is the total amount of time taken by the attacker.
 
@@ -1314,7 +1310,7 @@ This factor is not expressed in terms of time. The levels are as follows:
 
 *_Window of opportunity (Access to biometric characteristics)_* refers to measuring the difficulty to access the target biometric characteristics either to prepare the attack or to perform it on the target system
 
-Security evaluations of [CC] are dedicated to evaluate the intrinsic resistance of a system. Due to the potential number of attack paths (with or without the cooperation of an enrolled subject for example) the evaluation does not take into account the way a real biometric characteristic is acquired. For presentation attack detection, the vulnerability analysis is based on the hypothesis that a real "image" is available, and the rating only concerns the creation and the presentation of a PAI.
+Security evaluations of CC are dedicated to evaluate the intrinsic resistance of a system. Due to the potential number of attack paths (with or without the cooperation of an enrolled subject for example) the evaluation does not take into account the way a real biometric characteristic is acquired. For presentation attack detection, the vulnerability analysis is based on the hypothesis that a real "image" is available, and the rating only concerns the creation and the presentation of a PAI.
 
 However, it is important to be able to compare the resistance of various systems, even based on different biometrics. In addition, getting a real "image" to build a PAI is clearly part of an attack and it is of interest, for the final user of the TOE and the pertinence of a certificate to add a factor related to this aspect.
 
@@ -1504,11 +1500,11 @@ AVA_VAN.5
 |-
 |===
 
-=== Application notes for [BIOPP-Module] 
+=== Application notes for <<BIOPP-Module>> 
 
-Attack potential table <<attackpotentialcalc>> defined in previous Section doesn’t consider specific restrictions introduced by [BIOPP-Module]. For example, [BIOPP-Module] assumes that allowable maximum number of unsuccessful authentication attempts is limited that influence the calculation of *_Window of Opportunity (Access to TOE)_* for exploitation phase.
+Attack potential table <<attackpotentialcalc>> defined in previous Section doesn’t consider specific restrictions introduced by <<BIOPP-Module>>. For example, <<BIOPP-Module>> assumes that allowable maximum number of unsuccessful authentication attempts is limited that influence the calculation of *_Window of Opportunity (Access to TOE)_* for exploitation phase.
 
-The evaluator shall take following application notes into account to calculate the attack potential for [BIOPP-Module], especially calculating the attack potential for presentation attacks during performing EAs for FIA_MBV_EXT.3.
+The evaluator shall take following application notes into account to calculate the attack potential for <<BIOPP-Module>>, especially calculating the attack potential for presentation attacks during performing EAs for FIA_MBV_EXT.3.
 
 ==== Application note for Window of Opportunity (Access to TOE) for Identification
 
@@ -1530,9 +1526,9 @@ This Section provides the Pass/Fail criteria for EAs for FIA_MBV_EXT.3 taking th
 
 ==== Pass/Fail criteria
 
-The mobile device limits the number of unsuccessful authentication attempts for biometric verification, as required by [MDFPP]. Therefore, the attacker must succeed the presentation attack at least one time within this limit.
+The mobile device limits the number of unsuccessful authentication attempts for biometric verification, as required by <<MDFPP>>. Therefore, the attacker must succeed the presentation attack at least one time within this limit.
 
-This SD assumes that the attacker actually performs the presentation attack only if the attacker can create the “Reliable PAIs”. “Reliable PAIs” are those PAIs that succeed at least one attack within the allowable number of attempts (i.e. succeed to unlock the mobile device) at more than 80% of probability. This SD selects this probability based on the use case assumed in [BIOPP-Module].
+This SD assumes that the attacker actually performs the presentation attack only if the attacker can create the “Reliable PAIs”. “Reliable PAIs” are those PAIs that succeed at least one attack within the allowable number of attempts (i.e. succeed to unlock the mobile device) at more than 80% of probability. This SD selects this probability based on the use case assumed in <<BIOPP-Module>>.
 
 The probability of a successful presentation attack for one attempt *_p_* needs to satisfy the following equation to satisfy the above condition.
 
@@ -1551,7 +1547,7 @@ The following table shows that example of pairs (maximum *_p_* for particular *n
 |8 |0.18 (18%)
 |===
 
-The evaluator shall set *n* based on the assignment in FIA_AFL_EXT.1 in the ST that claim conformance to [MDFPP]. If the ST assign 5 to the maximum number of unsuccessful attempts for biometric verification, *n* should be 5. If the ST states that this number is configurable from 5 to 10, the evaluator shall assume the worst-case scenario and *n* should be 10.
+The evaluator shall set *n* based on the assignment in FIA_AFL_EXT.1 in the ST that claim conformance to <<MDFPP>>. If the ST assign 5 to the maximum number of unsuccessful attempts for biometric verification, *n* should be 5. If the ST states that this number is configurable from 5 to 10, the evaluator shall assume the worst-case scenario and *n* should be 10.
 
 The evaluator shall assign pass verdict to the TOE only if the evaluator can’t find those PAIs that the probability of successful attack is more than *_p_*.
 
@@ -1569,50 +1565,23 @@ Those PAIs can succeed at least one presentation attack (and succeed to unlock t
 
 Example of warnings is that the AGD guidance may warn that the biometric verification is less secure than a password and recommend using a password for security sensitive services.
 
-== References
-
-[BIOPP-Module] collaborative PP-Module for Biometric enrolment and verification - for unlocking the device –, May 01, Version 0.8, 2019
-
-[CC1] Common Criteria for Information Technology Security Evaluation, Part 1: Introduction and General Model +
-CCMB-2017-04-001, Version 3.1 Revision 5, April 2017
-
-[CC2] Common Criteria for Information Technology Security Evaluation, +
-Part 2: Security Functional Components, +
-CCMB-2017-04-002, Version 3.1 Revision 5, April 2017
-
-[CC3] Common Criteria for Information Technology Security Evaluation, +
-Part 3: Security Assurance Components, +
-CCMB-2017-04-003, Version 3.1 Revision 5, April 2017
-
-[CEM] Common Methodology for Information Technology Security Evaluation, +
-Evaluation Methodology, +
-CCMB-2017-04-004, Version 3.1 Revision 5, April 2017
-
-[addenda] CC and CEM addenda, +
-Exact Conformance, Selection-Based SFRs, Optional SFRs, +
-Version 0.5, May 2017
-
-[ISO/IEC 15408-4] Evaluation criteria for IT security – Part 4: Framework for the specification of evaluation methods and activities, under development.
-
-[ISO/IEC 19792] Security evaluation of biometrics, First edition.
-
-[ISO/IEC 19795-1] Biometric performance testing and reporting - Part 1: Principles and framework, First edition.
-
-[ISO/IEC 19795-2] Biometric performance testing and reporting - Part 2: Testing methodologies for technology and scenario evaluation, First edition.
-
-[ISO/IEC 19795-3] Biometric performance testing and reporting - Part 3: Modality-specific testing, First edition.
-
-[ISO/IEC 19989-1] Criteria and methodology for security evaluation of biometric systems – Part 1: framework, under development.
-
-[ISO/IEC 19989-2] Information technology - Security techniques - Criteria and methodology for security evaluation of biometric systems - Part 2: Biometric recognition performance
-
-[ISO/IEC 21879] Performance testing of biometrics on mobile devices
-
-[ISO/IEC 30107-1] Biometric presentation attack detection — Part 1: Framework, First edition.
-
-[ISO/IEC 30107-3] Biometric presentation attack detection — Part 3: Testing and reporting, First edition.
-
-[MDFPP] Protection Profile for Mobile Device Fundamentals, Version 3.2
-
-[Toolbox] *TBD*
-
+== Related Documents
+[bibliography]
+- [#CC1]#[CC1]#	Common Criteria for Information Technology Security Evaluation, Part 1: Introduction and General Model, CCMB-2017-04-001, Version 3.1 Revision 5, April 2017.         
+- [#CC2]#[CC2]# Common Criteria for Information Technology Security Evaluation, Part 2: Security Functional Components, CCMB-2017-04-002, Version 3.1 Revision 5, April 2017.    
+- [#CC3]#[CC3]#	Common Criteria for Information Technology Security Evaluation, Part 3: Security Assurance Components, CCMB-2017-04-003, Version 3.1 Revision 5, April 2017.    
+- [#CEM]#[CEM]#	Common Methodology for Information Technology Security Evaluation, Evaluation Methodology, CCMB-2017-04-004, Version 3.1 Revision 5, April 2017.    
+- [#addenda]#[addenda]#	CC and CEM addenda, Exact Conformance, Selection-Based SFRs, Optional SFRs, Version 0.5, May 2017.        
+- [#MDFPP]#[MDFPP]# Protection Profile for Mobile Device Fundamentals, Version:3.3.    
+- [#PPC-MDF]#[PPC-MDF]# PP-Configuration for Protection Profile for Mobile Device Fundamentals and collaborative PP-Module for Biometric enrolment and verification - for unlocking the device -, December 05, 2019, Version 0.91.    
+- [#BIOPP-Module]#[BIOPP-Module]# collaborative PP-Module for Biometric enrolment and verification - for unlocking the device -, December 5, 2019, Version 0.91.    
+- [#ISO/IEC 15408-4]#[ISO/IEC 15408-4]# Evaluation criteria for IT security – Part 4: Framework for the specification of evaluation methods and activities, under development.    
+- [#ISO/IEC 19792]#[ISO/IEC 19792]# Security evaluation of biometrics, First edition.    
+- [#ISO/IEC 19795-1]#[ISO/IEC 19795-1]# Biometric performance testing and reporting - Part 1: Principles and framework, First edition.    
+- [#ISO/IEC 19795-2]#[ISO/IEC 19795-2]# Biometric performance testing and reporting - Part 2: Testing methodologies for technology and scenario evaluation, First edition.    
+- [#ISO/IEC 19795-3]#[ISO/IEC 19795-3]# Biometric performance testing and reporting - Part 3: Modality-specific testing, First edition.    
+- [#ISO/IEC 19989-1]#[ISO/IEC 19989-1]# Criteria and methodology for security evaluation of biometric systems – Part 1: framework, under development.    
+- [#ISO/IEC 19989-2]#[ISO/IEC 19989-2]# Information technology - Security techniques - Criteria and methodology for security evaluation of biometric systems - Part 2: Biometric recognition performance.    
+- [#ISO/IEC 30107-1]#[ISO/IEC 30107-1]# Biometric presentation attack detection — Part 1: Framework, First edition.    
+- [#ISO/IEC 30107-3]#[ISO/IEC 30107-3]# Biometric presentation attack detection — Part 3: Testing and reporting, First edition.        
+- [#Toolbox]#[Toolbox]# *TBD*    

--- a/4_Methodology/BS_SD.adoc
+++ b/4_Methodology/BS_SD.adoc
@@ -441,7 +441,7 @@ The evaluator shall report the summary of result of EA defined above, especially
 
 ===== Objective of the EA
 
-[BIOPP-Module] assumes that the mobile device provides the Secure Execution Environment (SEE), an operating environment separate from the main mobile device operating system. Access to the SEE is highly restricted and may be made available through special processor modes, separate security processors or a combination to provide this separation.
+<<BIOPP-Module>> assumes that the mobile device provides the Secure Execution Environment (SEE), an operating environment separate from the main mobile device operating system. Access to the SEE is highly restricted and may be made available through special processor modes, separate security processors or a combination to provide this separation.
 
 Evaluation of this SEE is out of scope of <<BIOPP-Module>> and the evaluator doesn’t need to evaluate this environment itself. However, the evaluator shall examine that the TOE processes any plaintext biometric data within the security boundary of the SEE. The SEE is responsible for preventing any entities outside the environment from accessing plaintext biometric data.
 
@@ -668,7 +668,7 @@ The <<BIOPP-Module>> does not contain any selection-based requirements.
 
 The evaluator shall verify that the TOE prevents use of artificial Presentation Attack Instruments (PAI) during biometric enrolment. This section defines EAs derived from ASE_TSS.1, AGD_OPE.1 and ADV_FSP.1.
 
-The main part of EA for FIA_MBE_EXT.3 is evaluator’s testing using artificial PAI. The <<Evaluation Activities for FIA_MBV_EXT.3>> defines EAs for ATE_IND.1 and AVA_VAN.1 in detail that the evaluator shall perform during the testing during biometric verification. The evaluator shall follow the same EAs for evaluating presentation attack detection during biometric enrolment. 
+The main part of EA for FIA_MBE_EXT.3 is evaluator’s testing using artificial PAI. The <<Evaluation Activities for PAD testing>> defines EAs for ATE_IND.1 and AVA_VAN.1 in detail that the evaluator shall perform for PAD testing during the biometric verification. The same EAs can be applied to PAD testing during the biometric enrolment. 
 
 ===== Dependency
 
@@ -692,7 +692,7 @@ Following input is required from the developer.
 
 The evaluator shall examine the TSS and AGD guidance to check that the TSS or AGD guidance states that the TOE prevents the use of artificial PAI during biometric enrolment.
 
-Main part of EA is evaluator’s testing defined in <<Evaluation Activities for FIA_MBV_EXT.3>>. The evaluator should not require the detail design description of PAD from developer because it’s beyond the scope of assurance level claimed in <<BIOPP-Module>>.
+Main part of EA is evaluator’s testing defined in <<Evaluation Activities for PAD testing>>. The evaluator should not require the detail design description of PAD from developer because it’s beyond the scope of assurance level claimed in <<BIOPP-Module>>.
 
 ===== Pass/Fail criteria
 
@@ -711,7 +711,7 @@ The evaluator shall report the summary of result of EA defined above, especially
 
 The evaluator shall verify that the TOE prevents use of artificial Presentation Attack Instruments (PAI) during biometric verification. This section defines EAs derived from ASE_TSS.1, AGD_OPE.1 and ADV_FSP.1.
 
-The main part of EA for FIA_MBV_EXT.3 is evaluator’s testing using artificial PAI. The <<Evaluation Activities for FIA_MBV_EXT.3>> defines EAs for ATE_IND.1 and AVA_VAN.1 in detail that the evaluator shall perform during the testing.
+The main part of EA for FIA_MBV_EXT.3 is evaluator’s testing using artificial PAI. The <<Evaluation Activities for PAD testing>> defines EAs for ATE_IND.1 and AVA_VAN.1 in detail that the evaluator shall perform during the testing.
 
 ===== Dependency
 
@@ -735,7 +735,7 @@ Following input is required from the developer.
 
 The evaluator shall examine the TSS and AGD guidance to check that the TSS or AGD guidance states that the TOE prevents the use of artificial PAI during biometric verification.
 
-Main part of EA is evaluator’s testing defined in <<Evaluation Activities for FIA_MBV_EXT.3>>. The evaluator should not require the detail design description of PAD from developer because it’s beyond the scope of assurance level claimed in <<BIOPP-Module>>.
+Main part of EA is evaluator’s testing defined in <<Evaluation Activities for PAD testing>>. The evaluator should not require the detail design description of PAD from developer because it’s beyond the scope of assurance level claimed in <<BIOPP-Module>>.
 
 ===== Pass/Fail criteria
 
@@ -756,7 +756,7 @@ The evaluator shall refer the EA for FCS_CKM_EXT.4 in <<MDFPP>> to perform evalu
 
 == Evaluation Activities for SARs
 
-<<BIOPP-Module>> does not define any SARs beyond those defined within the <<MDFPP>> to which it can claim conformance. It is important to note that the TOE that is evaluated against <<BIOPP-Module>> is inherently evaluated against <<MDFPP>> as well. This means that EAs in <<Class ADV: Development>> (Security Assurance Requirements) in <<MDFPP>> should also applied to <<BIOPP-Module>> with additional application notes or EAs defined in the following Sections.
+<<BIOPP-Module>> does not define any SARs beyond those defined within the <<MDFPP>> to which it can claim conformance. It is important to note that the TOE that is evaluated against <<BIOPP-Module>> is inherently evaluated against <<MDFPP>> as well. This means that EAs in Section 5.2 *Security Assurance Requirements* in <<MDFPP>> should also applied to <<BIOPP-Module>> with additional application notes or EAs defined in the following Sections.
 
 === Class ASE: Security Target
 
@@ -794,7 +794,7 @@ The evaluator shall take the following additional application notes into account
 
 ==== Application note for EA of ATE_IND.1
 
-Same EA should be applied to <<BIOPP-Module>> except SFR FIA_MBV_EXT.3 (**Presentation attack detection for biometric verification**). The evaluator shall perform EAs defined in <<Evaluation Activities for FIA_MBV_EXT.3>> for FIA_MBV_EXT.3.
+Same EA should be applied to <<BIOPP-Module>> except optional requirement FIA_MBE_EXT.3 (**Presentation attack detection for biometric enrolment**) and FIA_MBV_EXT.3 (**Presentation attack detection for biometric verification**). The evaluator shall perform EAs defined in <<Evaluation Activities for PAD testing>> for FIA_MBE_EXT.3 and FIA_MBV_EXT.3.
 
 === Class AVA: Vulnerability Assessment
 
@@ -802,13 +802,13 @@ The evaluator shall take the following additional application notes into account
 
 ==== Application note for EA of AVA_VAN.1
 
-Same EA should be applied to <<BIOPP-Module>> except SFR FIA_MBV_EXT.3 (**Presentation attack detection for biometric verification**). The evaluator shall perform EAs defined in <<Evaluation Activities for FIA_MBV_EXT.3>> for FIA_MBV_EXT.3.
+Same EA should be applied to <<BIOPP-Module>> except optional requirement FIA_MBE_EXT.3 (**Presentation attack detection for biometric enrolment**) and FIA_MBV_EXT.3 (**Presentation attack detection for biometric verification**). The evaluator shall perform EAs defined in <<Evaluation Activities for PAD testing>> for FIA_MBE_EXT.3 and FIA_MBV_EXT.3.
 
-== Evaluation Activities for FIA_MBV_EXT.3
+== Evaluation Activities for PAD testing
 
 === Introduction
 
-The evaluator shall perform the following two types of EAs or testing to evaluate the FIA_MBV_EXT.3 (**Presentation attack detection for biometric verification**).
+The evaluator shall perform the following two types of EAs or testing to evaluate the FIA_MBE_EXT.3 (**Presentation attack detection for biometric enrolment**) and FIA_MBV_EXT.3 (**Presentation attack detection for biometric verification**). The following section defines EAs for FIA_MBV_EXT.3 however, the evaluator can rephrase "verification" with "enrolment" and apply the EAs to FIA_MBE_EXT.3. 
 
 [loweralpha]
 . EAs for ATE_IND.1 (Independent testing - conformance)
@@ -834,7 +834,7 @@ As described in previous section, <<Toolbox>> defines test items to create a rep
 
 During the independent testing, the evaluator may find PAIs that are incorrectly matched to the enrolled target user however, the evaluator may not be able to reliably reproduce a successful presentation attack.
 
-[Toolbox] defines the Pass/Fail criteria, maximum attack presentation match rate for PAIs. The evaluator shall follow the <<Toolbox>> criteria for the number of PAI presentations and confirm that the TOE’s match rate is below the specified criteria during the independent testing. The evaluator shall assign fail verdict to those TOE that doesn’t satisfy the criteria.
+<<Toolbox>> defines the Pass/Fail criteria, maximum attack presentation match rate for PAIs. The evaluator shall follow the <<Toolbox>> criteria for the number of PAI presentations and confirm that the TOE’s match rate is below the specified criteria during the independent testing. The evaluator shall assign fail verdict to those TOE that doesn’t satisfy the criteria.
 
 The PAIs that pass the criteria but show the higher attack presentation match rate will be tested again during the AVA_VAN.1 evaluation.
 
@@ -952,7 +952,7 @@ However, the evaluator shall not spend more than one week for independent and pe
 
 ===== Determine Pass/Fail of penetration testing
 
-The evaluator shall determine that the TOE, in its operational environment, is resistant to an attacker possessing a Basic attack potential. The evaluator shall make this determination based on guidance provided in  <<Pass/Fail criteria for EAs for FIA_MBV_EXT.3>> and maximum allowable error rates defined in <<Toolbox>>.
+The evaluator shall determine that the TOE, in its operational environment, is resistant to an attacker possessing a Basic attack potential. The evaluator shall make this determination based on guidance provided in  <<Pass/Fail criteria for EAs for PAD testing (FIA_MBE_EXT.3 and FIA_MBV_EXT.3)>> and maximum allowable error rates defined in <<Toolbox>>.
 
 ==== Justification for EAs for AVA_VAN.1
 
@@ -1514,7 +1514,7 @@ The evaluator shall select “Easy” because the TOE is the mobile device that 
 
 The evaluator shall select “Difficult” because number of unsuccessful authentication attempts for biometric verification is limited, and biometric verification become unusable if the number of failure attempts exceed the limit.
 
-=== Pass/Fail criteria for EAs for FIA_MBV_EXT.3
+=== Pass/Fail criteria for EAs for PAD testing (FIA_MBE_EXT.3 and FIA_MBV_EXT.3)
 
 As required by CC, the evaluator shall determine that the TOE is resistant to an attacker possessing a Basic attack potential based on <<attackpotentialcalc>>. However, the table doesn’t provide any guidance for the probability of success or failure of presentation attack.
 
@@ -1522,7 +1522,7 @@ The evaluator may have enough confidence to assign fail verdict to the TOE if th
 
 However, the evaluator can’t make an objective decision if the probability of success decreases at certain level because the mobile device limits the number of unsuccessful authentication attempts for biometric verification and the attacker can’t present the PAI to the TOE so many times in the actual operational environment.
 
-This Section provides the Pass/Fail criteria for EAs for FIA_MBV_EXT.3 taking this particular aspect into account so that the evaluator can make consistent and objective decision.
+This Section provides the Pass/Fail criteria for EAs for PAD testing taking this particular aspect into account so that the evaluator can make consistent and objective decision.
 
 ==== Pass/Fail criteria
 

--- a/4_Methodology/BS_SD.adoc
+++ b/4_Methodology/BS_SD.adoc
@@ -69,10 +69,7 @@ This Supporting Document was developed by the Biometric Security international T
 
 === Technology Area and Scope of Supporting Document
 
-This Supporting Document (SD) defines the Evaluation Activities (EAs) associated with the collaborative PP-Module for Biometric enrolment and verification - for unlocking the device - <<BIOPP-Module>> that is intended for use with the following base PP: +
-
-
-*Protection Profile for Mobile Device Fundamentals (<<MDFPP>>)*
+This Supporting Document (SD) defines the Evaluation Activities (EAs) associated with the collaborative PP-Module for Biometric enrolment and verification - for unlocking the device - <<BIOPP-Module>> that is intended for use with the base PP identified in the appropriate PP-Configuration.
 
 This SD is mandatory for evaluations of TOEs that claim conformance to <<BIOPP-Module>>.
 
@@ -92,7 +89,7 @@ In general, if all EAs (for both SFRs and SARs) are successfully completed in an
 
 ==== Glossary
 
-For definitions of standard CC terminology see <<CC1>>. For definitions of biometrics and mobile device, see <<BIOPP-Module>> and <<MDFPP>>.
+For definitions of standard CC terminology see <<CC1>>. For definitions of biometrics and mobile device, see <<BIOPP-Module>> and the base PP.
 
 ==== Acronyms
 
@@ -169,7 +166,7 @@ EAs in this SD provide specific or more detailed guidance to evaluate the biomet
 
 This Section explains how EAs for SFRs are derived from the particular CEM work units identified in Assessment Strategy to show the consistency and compatibility between the CEM work units and EAs in this SD.
 
-Assessment Strategy for ASE_TSS requires the evaluator to examine that the TSS provides sufficient design descriptions and its verdicts will be associated with the CEM work unit ASE_TSS.1-1. Evaluator verdicts associated with the supplementary information will also be associated with ASE_TSS.1-1, since the requirement to provide such evidence is specified in ASE in <<MDFPP>> from which SARs of <<BIOPP-Module>> are inherited.
+Assessment Strategy for ASE_TSS requires the evaluator to examine that the TSS provides sufficient design descriptions and its verdicts will be associated with the CEM work unit ASE_TSS.1-1. Evaluator verdicts associated with the supplementary information will also be associated with ASE_TSS.1-1, since the requirement to provide such evidence is specified in ASE in the base PP from which SARs of <<BIOPP-Module>> are inherited.
 
 Assessment Strategy for AGD_OPE/ADV_FSP requires the evaluator to examine that the AGD guidance provides sufficient information for the administrators/users as it pertains to SFRs, its verdicts will be associated with CEM work units ADV_FSP.1-7, AGD_OPE.1-4, and AGD_OPE.1-5.
 
@@ -181,7 +178,7 @@ Assessment Strategy for ATE_IND requires the evaluator to conduct testing that t
 
 ===== Objective of the EA
 
-The evaluator shall verify that the TOE enrols a user only after successful authentication of the user by his/her password. Security requirements for the password authentication are defined in <<MDFPP>> and out of scope of this EA.
+The evaluator shall verify that the TOE enrols a user only after successful authentication of the user by his/her password. Security requirements for the password authentication are defined in the base PP and out of scope of this EA.
 
 ===== Dependency
 
@@ -530,7 +527,7 @@ If the TOE transmits biometric data, the evaluator shall examine that the activi
 . The TOE never transmits plaintext biometric data to outside the SEE. This means;
 +
 [arabic]
-.. The TOE encrypts plaintext biometric data to be transmitted using the cryptographic functions evaluated based on <<MDFPP>> within the SEE
+.. The TOE encrypts plaintext biometric data to be transmitted using the cryptographic functions evaluated based on the base PP within the SEE
 .. If the TOE stores the encrypted biometric data outside the SEE for transmission, the TOE deletes such data after the transmission
 .. If the TOE displays the plaintext biometric data to the user to seek approval for transmission, such process is performed within the SEE
 
@@ -580,7 +577,7 @@ The evaluator shall examine the TSS to understand the activities that happen on 
 [loweralpha]
 . The TSS lists type of biometric data that the TOE stores in non-volatile memory outside the SEE
 . The TOE encrypts all plaintext biometric data listed in the TSS within the SEE before storing it in the non-volatile memory
-. The TOE uses cryptographic functions evaluated based on <<MDFPP>> to encrypt the data
+. The TOE uses cryptographic functions evaluated based on the base PP to encrypt the data
 
 ====== Strategy for ATE_IND
 
@@ -588,12 +585,12 @@ The evaluator shall perform the following test to verify that the TOE encrypts p
 
 The following test steps require the developer to provide access to a test platform that provides the evaluator with tools that are typically not found on factory products.
 
-. The evaluator shall check that all cryptographic algorithms listed in “file list/format and cryptographic algorithm” are successfully evaluated based on <<MDFPP>>
+. The evaluator shall check that all cryptographic algorithms listed in “file list/format and cryptographic algorithm” are successfully evaluated based on the base PP
 . The evaluator shall load an app onto the mobile device. This app shall attempt to traverse over all file systems and report any newly created files
 . The evaluator shall perform biometric enrolment and verification and run the app to list new files
 . The evaluator shall compare files reported by the app and ones listed in “file list/format and cryptographic algorithm”
 . If evaluator finds newly created files not listed in “file list/format and cryptographic algorithm”, the evaluator shall confirm that those files don’t include plaintext biometric data with the support from developer
-. For all files listed in “file list/format and cryptographic algorithm”, the evaluator shall display the contents of files and check that the files are encrypted. The evaluator can assume that encryption is done correctly because the TOE uses cryptographic algorithms evaluated based on <<MDFPP>>. The evaluator shall compare the content of files to the format defined in “file list/format and cryptographic algorithm” to check that the files don’t follow the defined format to implicitly assume files are encrypted.
+. For all files listed in “file list/format and cryptographic algorithm”, the evaluator shall display the contents of files and check that the files are encrypted. The evaluator can assume that encryption is done correctly because the TOE uses cryptographic algorithms evaluated based on the base PP. The evaluator shall compare the content of files to the format defined in “file list/format and cryptographic algorithm” to check that the files don’t follow the defined format to implicitly assume files are encrypted.
 
 ===== Pass/Fail criteria
 
@@ -752,57 +749,11 @@ The evaluator shall report the summary of result of EA defined above, especially
 
 ==== EA for FDP_RIP.2
 
-The evaluator shall refer the EA for FCS_CKM_EXT.4 in <<MDFPP>> to perform evaluation of this SFR.
+The evaluator shall refer the EA in the base PP to perform evaluation of this SFR (e.g. EA for FCS_CKM_EXT.4 in <<MDFPP>>).
 
 == Evaluation Activities for SARs
 
-<<BIOPP-Module>> does not define any SARs beyond those defined within the <<MDFPP>> to which it can claim conformance. It is important to note that the TOE that is evaluated against <<BIOPP-Module>> is inherently evaluated against <<MDFPP>> as well. This means that EAs in Section 5.2 *Security Assurance Requirements* in <<MDFPP>> should also applied to <<BIOPP-Module>> with additional application notes or EAs defined in the following Sections.
-
-=== Class ASE: Security Target
-
-<<MDFPP>> doesn’t define any EAs and there is no additional EAs for <<BIOPP-Module>>.
-
-=== Class ADV: Development
-
-Same EA defined in <<MDFPP>> should also be applied to <<BIOPP-Module>>.
-
-=== Class AGD: Guidance Documentation
-
-The evaluator shall take the following additional application notes into account to perform EAs defined in <<MDFPP>>.
-
-==== Application note for EA of AGD_OPE.1
-
-<<BIOPP-Module>> defines the assumptions for the mobile device that is the operational environment of the biometric system. These assumptions are implicitly satisfied if the mobile device is successfully evaluated based on <<MDFPP>> and the operational guidance doesn’t need to describe the security measures to be followed in order to fulfil the security objectives for the operational environment derived from those assumptions.
-
-There is additional application note related to EAs for FIA_MBV_EXT.3 in <<Additional application notes for AGD Class for FIA_MBV_EXT.3>>. The evaluator shall also follow this note depending on the result of the penetration testing for PAD.
-
-==== Application note for EA of AGD_PRE.1
-
-[BIOPP-Module] supposes that the biometric system is fully integrated into the mobile device and the preparative procedures are unnecessary for [BIOPP-Module]. Therefore, AGD_PRE.1 deems satisfied for <<BIOPP-Module>>.
-
-=== Class ALC: Life-cycle Support
-
-The evaluator shall take the following additional application notes into account to perform EAs defined in <<MDFPP>> for <<BIOPP-Module>>. There is no application note for EA for ALC_CMS.1 and ALC_TSU_EXT.
-
-==== Application note for EA of ALC_CMC.1
-
-<<BIOPP-Module>> is intended to be used with <<MDFPP>> and reference for the mobile device can be used as the TOE (mobile device + biometric system) reference only if the reference for the mobile device also uniquely identifies the biometric system embedded in the mobile device.
-
-=== Class ATE: Tests
-
-The evaluator shall take the following additional application notes into account to perform EAs defined in <<MDFPP>> for <<BIOPP-Module>>.
-
-==== Application note for EA of ATE_IND.1
-
-Same EA should be applied to <<BIOPP-Module>> except optional requirement FIA_MBE_EXT.3 (**Presentation attack detection for biometric enrolment**) and FIA_MBV_EXT.3 (**Presentation attack detection for biometric verification**). The evaluator shall perform EAs defined in <<Evaluation Activities for PAD testing>> for FIA_MBE_EXT.3 and FIA_MBV_EXT.3.
-
-=== Class AVA: Vulnerability Assessment
-
-The evaluator shall take the following additional application notes into account to perform EAs defined in <<MDFPP>> for <<BIOPP-Module>>.
-
-==== Application note for EA of AVA_VAN.1
-
-Same EA should be applied to <<BIOPP-Module>> except optional requirement FIA_MBE_EXT.3 (**Presentation attack detection for biometric enrolment**) and FIA_MBV_EXT.3 (**Presentation attack detection for biometric verification**). The evaluator shall perform EAs defined in <<Evaluation Activities for PAD testing>> for FIA_MBE_EXT.3 and FIA_MBV_EXT.3.
+[BIOPP-Module] does not define any SARs beyond those defined within the base PP to which it can claim conformance. However, additional application notes or EAs for SARs are defined in the appropriate PP-Configuration. 
 
 == Evaluation Activities for PAD testing
 
@@ -814,7 +765,7 @@ The evaluator shall perform the following two types of EAs or testing to evaluat
 . EAs for ATE_IND.1 (Independent testing - conformance)
 . EAs for AVA_VAN.1 (Vulnerability survey)
 
-ATE_IND.1 requires the evaluator to demonstrate that the TOE operates in accordance with its design representations described in TSS or AGD guidance (As described in <<MDFPP>>, a formal or complete specification of PAD interface is not required but the evaluator should examine interface information presented in the TSS and AGD guidance).
+ATE_IND.1 requires the evaluator to demonstrate that the TOE operates in accordance with its design representations described in TSS or AGD guidance because <<BIOPP-Module>> doesn't requre a formal or complete specification of PAD interface.
 
 However, <<BIOPP-Module>> doesn’t require such design representations about PAD (e.g. how the TOE checks the liveness of the object) in TSS or AGD because those information is beyond the scope of assurance level claimed by [BIOPP-Module]. Therefore, this SD doesn’t also require the evaluator to test the functional aspects of PAD based on those design representations.
 
@@ -1014,7 +965,7 @@ The test document shall report the following information to uniquely identify th
 [arabic]
 .. TOE reference
 +
-Information that uniquely identifes the TOE shall be reported. <<BIOPP-Module>> is intended to be used with <<MDFPP>> and reference for the mobile device can be used as the TOE reference only if the reference for the mobile device also uniquely identifies the biometric system embedded in the mobile device
+Information that uniquely identifes the TOE shall be reported. <<BIOPP-Module>> is intended to be used with the base PP and reference for the mobile device can be used as the TOE reference only if the reference for the mobile device also uniquely identifies the biometric system embedded in the mobile device
 +
 Modification to the TOE for performance testing, if any, shall be reported (e.g. The TOE is modified to export biometric data for off-line testing). The rationale that such modification doesn’t affect the TOE performance shall also be provided. For example, the developer may claim that the performance is not affected because modified code isn’t executed during biometric verification or the developer may run regression test to verify that modification doesn’t change the result of verification (e.g. similarity score).
 .. TOE configuration
@@ -1175,7 +1126,7 @@ Suppose the mobile device provides both Password Authentication Factor and BAF a
 
 It may also be possible for user to enrol multiple body parts (e.g. index and thumb fingerprint) or single body part for biometric verification.
 
-However, it’s not possible to evaluate all these scenarios to measure the performance but the developer shall refer the ST that claims conformance to <<MDFPP>> to define the scenario.
+However, it’s not possible to evaluate all these scenarios to measure the performance but the developer shall refer the ST that claims conformance to the base PP to define the scenario.
 
 For example, if the ST sets the maximum number of unsuccessful authentication attempts for mobile fingerprint verification to five, the developer shall assume that the attacker makes all five fingerprint unlock attempts in succession to try to unlock the mobile device.
 
@@ -1197,7 +1148,7 @@ The developer shall define the maximum number of samples per test subject to be 
 
 ==== Maximum number of transactions per test subject
 
-Only one transaction can be run by each test subject because the mobile device locks the biometric verification as required by <<MDFPP>> after the certain number of attempts are failed.
+Only one transaction can be run by each test subject because the mobile device locks the biometric verification as required by the base PP after the certain number of attempts are failed.
 
 ==== Statistical certainty for FAR/FMR
 
@@ -1526,7 +1477,7 @@ This Section provides the Pass/Fail criteria for EAs for PAD testing taking this
 
 ==== Pass/Fail criteria
 
-The mobile device limits the number of unsuccessful authentication attempts for biometric verification, as required by <<MDFPP>>. Therefore, the attacker must succeed the presentation attack at least one time within this limit.
+The mobile device limits the number of unsuccessful authentication attempts for biometric verification, as required by the base PP. Therefore, the attacker must succeed the presentation attack at least one time within this limit.
 
 This SD assumes that the attacker actually performs the presentation attack only if the attacker can create the “Reliable PAIs”. “Reliable PAIs” are those PAIs that succeed at least one attack within the allowable number of attempts (i.e. succeed to unlock the mobile device) at more than 80% of probability. This SD selects this probability based on the use case assumed in <<BIOPP-Module>>.
 
@@ -1547,7 +1498,7 @@ The following table shows that example of pairs (maximum *_p_* for particular *n
 |8 |0.18 (18%)
 |===
 
-The evaluator shall set *n* based on the assignment in FIA_AFL_EXT.1 in the ST that claim conformance to <<MDFPP>>. If the ST assign 5 to the maximum number of unsuccessful attempts for biometric verification, *n* should be 5. If the ST states that this number is configurable from 5 to 10, the evaluator shall assume the worst-case scenario and *n* should be 10.
+If the base PP is <<MDFPP>, the evaluator shall set *n* based on the assignment in FIA_AFL_EXT.1 in the ST. If the ST assign 5 to the maximum number of unsuccessful attempts for biometric verification, *n* should be 5. If the ST states that this number is configurable from 5 to 10, the evaluator shall assume the worst-case scenario and *n* should be 10.
 
 The evaluator shall assign pass verdict to the TOE only if the evaluator can’t find those PAIs that the probability of successful attack is more than *_p_*.
 


### PR DESCRIPTION
This PR will update PP-Module, PP-Configuration and SD in Move-MDFPP-to-PPC branch to implement following changes;

1) Change PAD (FIA_MBV_EXT.3) to optional requirement in all documents
2) Change the format of the PP-Configuration referring the CC and latest draft of ISO/IEC 15408-1
3) Editorial changes (e.g. change "mobile biometric verification" to "biometric verification") in all documents

To implement above changes, you have to merge this PR into Move-MDFPP-to-PPC branch first and then merge #189 Move MDFPP references to PPC into master
