### PR TITLE
update to add assessment criteria link

### DIFF
--- a/4_Methodology/BS_SD.adoc
+++ b/4_Methodology/BS_SD.adoc
@@ -253,7 +253,7 @@ Following input is required from the developer.
 [loweralpha]
 . TSS shall explain how the TOE meets FIA_MBE_EXT.2 at high level description
 . AGD guidance shall provide clear instructions for a user to enrol him/herself
-. Supplementary information (Assessment criteria for templates) shall describe assessment criteria for creating templates
+. Supplementary information ([#assessment criteria for templates]#Assessment criteria for templates#) shall describe assessment criteria for creating templates
 
 AGD guidance may include online assistance, errors, prompts or warning provided by the TOE during the enrolment attempt.
 
@@ -266,7 +266,7 @@ AGD guidance may include online assistance, errors, prompts or warning provided 
 
 The evaluator shall examine the TSS to understand how the TOE generate templates of sufficient quality at enrolment. The evaluator shall also examine the AGD guidance about how the TOE supports a user to enrol him/herself correctly and how the TOE behaves when low quality samples are presented to the TOE.
 
-The evaluator shall examine that “assessment criteria for templates” to check that how the TOE creates the templates based on this assessment criteria. The “assessment criteria for templates” may include;
+The evaluator shall examine that <<assessment criteria for templates>> to check that how the TOE creates the templates based on this assessment criteria. The <<assessment criteria for templates>> may include;
 
 [loweralpha]
 . Quality requirements for the biometric sample to ensure that a sufficient amount of distinctive features is available
@@ -278,7 +278,7 @@ The evaluator shall examine that “assessment criteria for templates” to chec
 
 If the TOE creates authentication templates, the evaluator shall examine the TSS to understand how the TOE generate sufficient quality of authentication templates.
 
-The evaluator shall examine that the “assessment criteria for templates” to check that how the TOE creates the authenticate templates based on its assessment criteria. The “assessment criteria for templates” may include a) – d) in <<MBE2>> and;
+The evaluator shall examine that the <<assessment criteria for templates>> to check that how the TOE creates the authenticate templates based on its assessment criteria. The <<assessment criteria for templates>> may include a) – d) in <<MBE2>> and;
 
 [loweralpha, start=5]
 . Additional assessment criteria to applied to creation of authentication templates
@@ -291,9 +291,9 @@ The evaluator shall perform the following test to verify that the TOE generates 
 
 The following test steps require the developer to provide access to a test platform that provides the evaluator with tools that are typically not found on factory products.
 
-. The evaluator shall perform biometric enrolment that results in creation of templates that don’t satisfy the assessment criteria described in “assessment criteria for templates” (e.g. presenting biometric samples of low quality)
-. The evaluator shall check the TOE internal data (e.g. quality scores and quality threshold) to confirm that the TOE doesn’t create enrolment templates that don’t meet the assessment criteria specified in the “assessment criteria for templates”
-. The evaluator shall check the TOE internal data (e.g. quality scores and quality threshold) to confirm that any enrolment templates created by TOE meet the assessment criteria specified in the “assessment criteria for templates” correctly
+. The evaluator shall perform biometric enrolment that results in creation of templates that don’t satisfy the assessment criteria described in <<assessment criteria for templates>> (e.g. presenting biometric samples of low quality)
+. The evaluator shall check the TOE internal data (e.g. quality scores and quality threshold) to confirm that the TOE doesn’t create enrolment templates that don’t meet the assessment criteria specified in the <<assessment criteria for templates>>
+. The evaluator shall check the TOE internal data (e.g. quality scores and quality threshold) to confirm that any enrolment templates created by TOE meet the assessment criteria specified in the <<assessment criteria for templates>> correctly
 
 *Authentication templates*
 
@@ -303,15 +303,15 @@ The following test steps require the developer to provide access to a test platf
 
 . The evaluator shall enrol him/herself
 . The evaluator shall present biometric samples repeatedly to trigger the TOE to create authentication templates
-. The evaluator shall check the TOE internal data (e.g. quality scores and quality threshold) to confirm that the TOE doesn’t create authentication templates that don’t meet the assessment criteria specified in the “assessment criteria for templates”
-. The evaluator shall check the TOE internal data (e.g. quality scores and quality threshold) to confirm that any authentication templates created by TOE meet the assessment criteria specified in the “assessment criteria for templates” correctly
+. The evaluator shall check the TOE internal data (e.g. quality scores and quality threshold) to confirm that the TOE doesn’t create authentication templates that don’t meet the assessment criteria specified in the <<assessment criteria for templates>>
+. The evaluator shall check the TOE internal data (e.g. quality scores and quality threshold) to confirm that any authentication templates created by TOE meet the assessment criteria specified in the <<assessment criteria for templates>> correctly
 
 ===== Pass/Fail criteria
 
 The evaluator can pass this EA only if the evaluator confirms that:
 
 [loweralpha]
-. Information necessary to perform this EA is described in the TSS, AGD guidance and “assessment criteria for templates”
+. Information necessary to perform this EA is described in the TSS, AGD guidance and <<assessment criteria for templates>>
 . The TOE creates only templates that pass the assessment criteria through the independent testing
 
 ===== Requirements for reporting


### PR DESCRIPTION
Added a link for all parts where the assessment criteria for templates is mentioned, so it points back to the original location in the document where it was mentioned.

This is to close #230 