### PR TITLE
Change password to Non-Biometric Authentication Factor

### DIFF
--- a/3_ProtectionProfile/BiocPP.adoc
+++ b/3_ProtectionProfile/BiocPP.adoc
@@ -51,6 +51,8 @@ Artefact::
 	Biometric characteristic or object used in a presentation attack (e.g. artificial or abnormal biometric characteristics). Accompanying [BIOSD] specifies artefacts that the evaluator should consider for the CC evaluation. Specifically, the artefacts here are artificially generated Presentation Attack Instruments (PAI), not natural ones.
 Attempt::
    Submission of one (or a sequence of) biometric samples to the part of the TOE.
+(Non-Biometric) Authentication Factor (NBAF)::
+    Evidence to assert the identity of an individual based on knowledge or possession (e.g. password, PIN, smartcard).
 Biometric Authentication Factor (BAF)::
 	Authentication factor used for biometric verification. In this PP-Module, the term is a synonym of the “template”.
 Biometric Characteristic::
@@ -58,7 +60,7 @@ Biometric Characteristic::
 Biometric Claim::
 	A claim that a biometric capture subject is or is not the source of a specified or unspecified biometric reference.
 Biometric Data::
-	Digital data created during biometric enrolment and verification processes. It encompasses raw sensor observations, biometric samples, features, templates, and/or similarity scores, among other data. This data is used to describe the information collected, and does not include end user information such as user name, password (unless tied to the biometric modality), demographic information, and authorizations.
+	Digital data created during biometric enrolment and verification processes. It encompasses raw sensor observations, biometric samples, features, templates, and/or similarity scores, among other data. This data is used to describe the information collected, and does not include end user information such as user name, authentication factor (unless tied to the biometric modality), demographic information, and authorizations.
 Biometric Probe::
 	Biometric sample or biometric feature set input to an algorithm for use as the subject of biometric comparison to a biometric reference(s).
 Computer::
@@ -81,8 +83,6 @@ Locked State::
 	Powered on Computer, with most functionalities unavailable for use. User authentication is required to access full functionality.
 (Biometric) Modality::
 	A type or class of biometric system, such as fingerprint recognition, facial recognition, eye/iris recognition, voice recognition, signature/sign, and others.
-Password Authentication Factor::
-	A type of authentication factor requiring the user to provide a secret set of characters to gain access.
 Presentation::
 	Submission of a single biometric sample on the part of a user.
 Presentation Attack::
@@ -160,7 +160,7 @@ a)	Biometric enrolment
 
 During the enrolment process, the TOE captures samples from the biometric characteristics of a user presented to the TOE and extracts the features from the samples. The features are then stored as a template in the TOE.
 
-Only a user who knows the computer password can enrol or revoke his/her own templates. Multiple templates may be enrolled, as separate entries uniquely identified by the TOE, and optionally uniquely identifiable by the user (through the computer's User Interface).
+Only a user who knows the computer NBAF can enrol or revoke his/her own templates. Multiple templates may be enrolled, as separate entries uniquely identified by the TOE, and optionally uniquely identifiable by the user (through the computer's User Interface).
 
 b)	Biometric verification
 
@@ -187,7 +187,7 @@ As illustrated in the above figure, the TOE is capable of:
 ==== Relation between TOE and Computer 
 The TOE is reliant on the computer itself to provide overall security of the system. This PP-Module is intended to be used with a base PP, and the base PP is responsible for evaluating the following security functions:
 
-* Providing the Password Authentication Factor to support user authentication and management of the TOE security function
+* Providing the NBAF to support user authentication and management of the TOE security function
 * Invoking the TOE to enrol and verify the user and take appropriate actions based on the decision of the TOE
 * Providing the secure execution environment that guarantees the TOE and its data to be protected with respect to confidentiality and integrity
 
@@ -203,7 +203,7 @@ The computer itself may be operated in a number of use cases such as enterprise 
 This PP-Module only assumes USE CASE 1 described below. USE CASE 2 is out of scope of this PP-Module.
 
 ===== USE CASE 1: Biometric verification for unlocking the computer
-This use case is applicable for any computers such as desktop, laptop, tablet or smartphone that implement biometric enrolment and verification functionality. For enhanced security that is easy to use, the computer may implement biometric verification on a computer once it has been “unlocked”. The initial unlock is generally done by a PIN/password which is required at startup (or possibly after some period of time), and after that, the user is able to use their own biometric characteristic to unlock access to the computer. In this use case, the computer is not supposed to be used for security sensitive services through the biometric verification.
+This use case is applicable for any computers such as desktop, laptop, tablet or smartphone that implement biometric enrolment and verification functionality. For enhanced security that is easy to use, the computer may implement biometric verification on a computer once it has been “unlocked”. The initial unlock is generally done by a NBAF which is required at startup (or possibly after some period of time), and after that, the user is able to use their own biometric characteristic to unlock access to the computer. In this use case, the computer is not supposed to be used for security sensitive services through the biometric verification.
 
 The main concern of this use case is the accuracy of the biometric verification (i.e. FAR/FMR and FRR/FNMR). Security assurance for computer that the TOE relies on should be handled by the base PP.
 
@@ -215,7 +215,7 @@ It is also assumed that the user enrols his/herself correctly, following the gui
 
 This use case is an example of another use case that isn’t considered in this PP-Module. Another PP or PP-Module should be developed at higher assurance level for this use case.
 
-Computers may be used for security sensitive services such as payment transactions and online banking. Verification may be done by the biometric for convenience instead of PIN/password to access such security sensitive services.
+Computers may be used for security sensitive services such as payment transactions and online banking. Verification may be done by the biometric for convenience instead of the NBAF to access such security sensitive services.
 
 The requirements for the TOE focus on the biometric performance (FTE, FAR/FMR and FRR/FNMR) and presentation attack detection.
 
@@ -294,7 +294,7 @@ SFR Rationale:
 
 Requirements to provide a biometric enrolment mechanism is defined in FIA_MBE_EXT.1. Requirement for quality of template is defined in FIA_MBE_EXT.2.
 
-*Application Note {counter:remark_count}*:: A user shall be authenticated using a Password Authentication Factor to enrol his/herself.
+*Application Note {counter:remark_count}*:: A user shall be authenticated using a NBAF to enrol his/herself.
 
 *Application Note {counter:remark_count}*:: In this PP-Module, relevant criteria are FAR/FMR and FRR/FNMR and corresponding error rates shall be specified in the FIA_MBV_EXT.1.
 
@@ -314,7 +314,7 @@ The TOE environment shall provide an alternative authentication mechanism as a c
 
 *Application Note {counter:remark_count}*:: The TOE environment (i.e. the computer) shall satisfy relevant requirements defined in base PP.
 
-*Application Note {counter:remark_count}*:: The TOE environment (i.e. the computer) shall provide an alternative authentication mechanism such as a Password Authentication Factor.
+*Application Note {counter:remark_count}*:: The TOE environment (i.e. the computer) shall provide an alternative authentication mechanism such as a NBAF.
 
 [[OE.Authentication]]OE.Authentication::
 The TOE environment shall invoke the TOE for biometric verification, and take appropriate actions based on the TOE’s decision.
@@ -381,7 +381,7 @@ Extended SFRs are identified by having a label “EXT” at the end of the SFR n
 
 *FIA_MBE_EXT.1.1*:: The TSF shall provide a mechanism to enrol an authenticated user.
 
-*Application Note {counter:remark_count}*:: User shall be authenticated by the computer using the Password Authentication Factor before beginning biometric enrolment.
+*Application Note {counter:remark_count}*:: User shall be authenticated by the computer using the NBAF before beginning biometric enrolment.
 
 ==== FIA_MBE_EXT.2 Quality of biometric templates for biometric enrolment [[FIA_MBE_EXT.2]]
 

--- a/3_ProtectionProfile/PP_Config.adoc
+++ b/3_ProtectionProfile/PP_Config.adoc
@@ -123,7 +123,7 @@ The following rationale identifies several SFRs from <<MDFPP>> that are needed t
 Relation between SFRs defined in the <<MDFPP>> and SFRs and OEs in the <<BIOPP-Module>> is described below for each security functionality. *Bold SFRs* are those SFRs defined in the <<BIOPP-Module>> for the Biometric System and _italicized SFRs_ are those defined in <<MDFPP>> for the mobile device.
 
 ===== Password authentication
-Mobile device shall implement the Password Authentication Factor as required by the _FIA_UAU.5.1._ This password authentication is used as an alternative authentication mechanism when the user is rejected by the biometric verification.
+The Password Authentication Factor defined in the <<PP_MD_V3.3>> is a Non-Biometric Authentication Factor as defined in the <<BIOPP-Module>>. Mobile device shall implement the Password Authentication Factor as required by the _FIA_UAU.5.1._ This password authentication is used as an alternative authentication mechanism when the user is rejected by the biometric verification.
 
 The <<BIOPP-Module>> assumes that above requirements are satisfied by the mobile device as defined in OE.Alternative.
 

--- a/4_Methodology/BS_SD.adoc
+++ b/4_Methodology/BS_SD.adoc
@@ -107,6 +107,7 @@ For definitions of standard CC terminology see <<CC1>>. For definitions of biome
 |*cPP* |collaborative Protection Profile
 |*EA* |Evaluation Activity
 |*iTC* |International Technical Community
+|*NBAF* |(Non-Biometric) Authentication Factor
 |*PAI* |Presentation Attack Instrument (artefact)
 |*PP* |Protection Profile
 |*SAR* |Security Assurance Requirement
@@ -183,7 +184,7 @@ Assessment Strategy for ATE_IND requires the evaluator to conduct testing that t
 
 ===== Objective of the EA
 
-The evaluator shall verify that the TOE enrols a user only after successful authentication of the user by his/her password. Security requirements for the password authentication are defined in the base PP and out of scope of this EA.
+The evaluator shall verify that the TOE enrols a user only after successful authentication of the user by his/her NBAF. Security requirements for the NBAF mechanism are defined in the base PP and out of scope of this EA.
 
 ===== Dependency
 
@@ -207,14 +208,14 @@ AGD guidance may include online assistance, errors, prompts or warning provided 
 
 ====== Strategy for ASE_TSS and AGD_OPE/ADV_FSP
 
-The evaluator shall examine the TSS to understand how the TOE enrols a user and examine the AGD guidance to confirm that a user is required to enter his/her valid password before the biometric enrolment.
+The evaluator shall examine the TSS to understand how the TOE enrols a user and examine the AGD guidance to confirm that a user is required to enter his/her valid NBAF before the biometric enrolment.
 
 ====== Strategy for ATE_IND
 
 The evaluator shall perform the following steps to verify that the TOE performs the biometric enrolment correctly.
 
-. The evaluator shall try to enrol him/herself without setting a password and confirm that he/she can’t enrol him/herself.
-. The evaluator shall set a password and confirm that he/she can’t enrol him/herself without entering the password correctly beforehand.
+. The evaluator shall try to enrol him/herself without setting a NBAF and confirm that he/she can’t enrol him/herself.
+. The evaluator shall set a NBAF and confirm that he/she can’t enrol him/herself without entering the NBAF correctly beforehand.
 
 ===== Pass/Fail criteria
 
@@ -222,7 +223,7 @@ The evaluator can pass this EA only if the evaluator confirms that:
 
 [loweralpha]
 . Information necessary to perform this EA is described in the TSS and AGD guidance
-. Only authenticated users by password can enrol him/herself and any attempts to enrol without the authentication are rejected through the independent testing
+. Only authenticated users by NBAF can enrol him/herself and any attempts to enrol without the authentication are rejected through the independent testing
 
 ===== Requirements for reporting
 
@@ -616,7 +617,7 @@ The evaluator shall report the summary of result of EA defined above, especially
 
 ===== Objective of the EA
 
-Only an authenticated user can add his/her own templates during biometric enrolment as defined in the FIA_MBE_EXT.1 and those templates are not stored outside the SEE without encryption as required by the FPT_BDP_EXT.3. However, the TOE may provide functions (e.g. revocation of templates) to access the templates. The evaluator shall confirm that only authenticated user either using a PIN, password or by other secure means, as specified by the ST author can access the templates through the TSFI provided by the TOE.
+Only an authenticated user can add his/her own templates during biometric enrolment as defined in the FIA_MBE_EXT.1 and those templates are not stored outside the SEE without encryption as required by the FPT_BDP_EXT.3. However, the TOE may provide functions (e.g. revocation of templates) to access the templates. The evaluator shall confirm that only authenticated user either using a NBAF, as specified by the ST author can access the templates through the TSFI provided by the TOE.
 
 ===== Dependency
 
@@ -638,14 +639,14 @@ Following input is required from the developer.
 
 ====== Strategy for ASE_TSS and AGD_OPE/ADV_FSP
 
-The evaluator shall examine the TSS and AGD guidance to identify any TSFI through which the user can access (e.g. revoke) the templates. The evaluator shall confirm that those TSFI requires either using a PIN, password or by other secure means, as specified by the ST author.
+The evaluator shall examine the TSS and AGD guidance to identify any TSFI through which the user can access (e.g. revoke) the templates. The evaluator shall confirm that those TSFI requires either using a NBAF, as specified by the ST author.
 
 ====== Strategy for ATE_IND
 
 The evaluator shall perform the following test steps to verify that the TOE protects the templates as specified in TSS and AGD guidance.
 
 . The evaluator shall perform functions through the TSFIs that access the templates
-. The evaluator shall check that the TSFI requires either using a PIN, password or by other secure means, as specified by the ST author.
+. The evaluator shall check that the TSFI requires either using a NBAF, as specified by the ST author.
 
 ===== Pass/Fail criteria
 
@@ -653,7 +654,7 @@ The evaluator can pass this EA only if the evaluator confirms that:
 
 [loweralpha]
 . Information necessary to perform this EA is described in the TSS and AGD guidance
-. The TOE protects the templates either using a PIN, password or by other secure means, as specified by the ST author
+. The TOE protects the templates either using a NBAF, as specified by the ST author
 
 ===== Requirements for reporting
 
@@ -835,7 +836,7 @@ If the evaluator can find new artefact species, the evaluator shall consider the
 [loweralpha]
 . Attacker’s motivation
 +
-For enhanced security that is easy to use, the TOE implements biometric verification on a device once it has been “unlocked”. The initial unlock is generally done by a PIN/password which is required at startup (or possibly after some period of time), and after that the user is able to use a registered biometric characteristic to unlock access to the computer. The BIOSD assumes that the biometric verification is being used in accordance with USE CASE 1: Biometric verification for unlocking the computer.
+For enhanced security that is easy to use, the TOE implements biometric verification on a device once it has been “unlocked”. The initial unlock is generally done by a NBAF which is required at startup (or possibly after some period of time), and after that the user is able to use a registered biometric characteristic to unlock access to the computer. The BIOSD assumes that the biometric verification is being used in accordance with USE CASE 1: Biometric verification for unlocking the computer.
 +
 Attacker may use any tools or materials that are normally available at home and normal office environment such as laptop PC or office printer to attack the TOE. Attacker may also use any services (e.g. printing services to print a high-resolution photo of target users to create a face artefact) if such services are available at low cost.
 
@@ -1142,7 +1143,7 @@ The developer shall follow the guidance in this Section to define the transactio
 
 The user may use the biometric verification in a different way.
 
-Suppose the computer provides both Password Authentication Factor and BAF and the user can use either factor to unlock the device. One user may try to unlock the device with BAF until allowable maximum number of unsuccessful authentication attempts is exceeded. Another user may try to unlock the device with BAF only three times and switch to the password if all three attempts were failed.
+Suppose the computer provides both NBAF and BAF and the user can use either factor to unlock the device. One user may try to unlock the device with BAF until allowable maximum number of unsuccessful authentication attempts is exceeded. Another user may try to unlock the device with BAF only three times and switch to the NBAF if all three attempts were failed.
 
 It may also be possible for user to enrol multiple body parts (e.g. index and thumb fingerprint) or single body part for biometric verification.
 
@@ -1524,7 +1525,7 @@ The evaluator shall examine that appropriate warnings is provided in the AGD gui
 
 Those artefacts can succeed at least one presentation attack (and succeed to unlock the computer) at 25% of probability when allowable number of unsuccessful attempts is 4 (i.e. *n* = 4).
 
-Example of warnings is that the AGD guidance may warn that the biometric verification is less secure than a password and recommend using a password for security sensitive services.
+Example of warnings is that the AGD guidance may warn that the biometric verification is less secure than a NBAF and recommend using a NBAF for security sensitive services.
 
 == Related Documents
 [bibliography]


### PR DESCRIPTION
I have changed password and password authentication factor to non-biometric authentication factor to handle the options that may be in use on PCs such as smart cards.

I didn't use straight up "authentication factor" since we had a specific definition for biometric authentication factor and technically AF would include biometric, so I specifically adjusted it to be knowledge/possession based.

This is to close #265