### PR TITLE
Create PP_Config-OS.adoc

### DIFF
--- a/3_ProtectionProfile/PP_Config-OS.adoc
+++ b/3_ProtectionProfile/PP_Config-OS.adoc
@@ -16,7 +16,7 @@ This PP-Configuration was developed by the Biometrics Security international Tec
 
 The purpose of a PP-Configuration is to define a Target of Evaluation (TOE) that combines Protection Profiles (PPs) and PP-Modules for various technology types into a single configuration that can be evaluated as a whole. The scope includes the definition of the configuration of a computer (a computer in the terms of the PP-Module) that has biometric enrolment and verification capability. The TOE will be defined by a combination of the components described in <<PP-Configuration Components Statement>>.
 
-The computer for the purposes of this PP-Configuration is a system with a General Purpose Operating System plus a Biometric System. The Biometric System may be directly integrated into the physical computer or an external component that has been linked/paired with the physical computer and for which biometric credentials are linked specifically to the paired computer (i.e. templates registered on computer 1 cannot be used on computer 2).
+The TOE for the purposes of this PP-Configuration is a system with a General Purpose Operating System plus a Biometric System. The Biometric System may be directly integrated into the TOE, or may include an external component that has been incorporated as part of the TOE platform and for which biometric credentials are linked specifically to the TOE platform (i.e. templates registered on TOE platform 1 cannot be used on TOE platform 2).
 
 == PP-Configuration Reference
 
@@ -41,7 +41,7 @@ This section describes consistency rationale between <<PP_OS_V4.3>> and <<BIOPP-
 
 === Consistency of TOE Type
 
-When the <<BIOPP-Module>> is used to extend <<PP_OS_V4.3>>, the TOE type for the overall TOE is still a general purpose operating system. However, one of the functions of the operating system and computer must be the ability for it to have biometric enrolment and verification capability. The TOE boundary is simply extended to include that functionality.
+When the <<BIOPP-Module>> is used to extend <<PP_OS_V4.3>>, the TOE type for the overall TOE is still a general purpose operating system. However, one of the functions of the TOE must be the ability for it to have biometric enrolment and verification capability. The TOE boundary is simply extended to include that functionality.
 
 === Consistency of Security Problem Definition
 
@@ -71,7 +71,7 @@ The threats, OSPs and assumptions defined by the <<BIOPP-Module>> (see the Secti
 |Consistency Rationale
 
 |A.Alternative	
-.3+|All assumptions levied on the operational environment of biometric system (i.e. The computer) are consistent with security requirements in the <<PP_OS_V4.3>>. 
+.3+|All assumptions levied on the operational environment of biometric system (i.e. the computer) are consistent with security requirements in the <<PP_OS_V4.3>>. 
 |A.Authentication
 |A.User
 
@@ -103,7 +103,7 @@ The objectives for the biometric system and its operational environment are cons
 |Consistency Rationale
 
 |OE.Alternative	
-.4+|All Environmental Objectives levied on the operational environment of biometric system (i.e. The computer) are consistent with security requirements in the <<PP_OS_V4.3>>. 
+.4+|All Environmental Objectives levied on the operational environment of biometric system (i.e. the computer) are consistent with security requirements in the <<PP_OS_V4.3>>. 
 |OE.Authentication
 |OE.Protection
 |OE.User
@@ -112,44 +112,44 @@ The objectives for the biometric system and its operational environment are cons
 
 === Consistency of Requirements
 
-The Biometric System (i.e. TSF in the <<BIOPP-Module>>) is comprised of biometric capture sensors and firmware/software that provide functions described in the <<BIOPP-Module>> TOE design. The Biometric System may be integral to the computer or an external (self-contained) device that has been linked/paired with the computer. The Biometric System is invoked by the computer as defined in the <<PP_OS_V4.3>> when user’s biometric characteristics is presented to the sensor. The Biometric System creates and stores the template or compares the features with the stored template and returns the verification outcome to the computer.
+The Biometric System (i.e. TSF in the <<BIOPP-Module>>) is comprised of biometric capture sensors and firmware/software that provide functions described in the <<BIOPP-Module>> TOE design. The TOE platform includes a Biometric System that may be integral to the GPOS TOE platform or extended to include an external (self-contained) device that has been linked/paired with the GPOS TOE platform. The Biometric System is invoked by the TSF as defined in the <<PP_OS_V4.3>> when user’s biometric characteristics is presented to the sensor. The Biometric System creates and stores the template or compares the features with the stored template and returns the verification outcome to the TOE.
 
-The <<BIOPP-Module>> assumes that the computer satisfies SFRs defined in the <<PP_OS_V4.3>> so that the Biometric System can work as specified in the <<BIOPP-Module>>. This section explains which SFRs in the <<PP_OS_V4.3>> are directly relevant to the Biometric System security functionality.
+The <<BIOPP-Module>> assumes that the TOE satisfies SFRs defined in the <<PP_OS_V4.3>> so that the Biometric System can work as specified in the <<BIOPP-Module>>. This section explains which SFRs in the <<PP_OS_V4.3>> are directly relevant to the Biometric System security functionality.
 
 The following rationale identifies several SFRs from <<PP_OS_V4.3>> that are needed to support Biometric System functionality and explains why the unions of SFRs in the <<PP_OS_V4.3>> and <<BIOPP-Module>> do not lead to a contradiction.
 
 ==== Relation among SFRs/OEs in the PP_OS_V4.3 and BIOPP-Module
-The relation between SFRs defined in the <<PP_OS_V4.3>> and SFRs and OEs in the <<BIOPP-Module>> is described below for each security functionality. *Bold SFRs* are those SFRs defined in the <<BIOPP-Module>> for the Biometric System and _italicized SFRs_ are those defined in <<PP_OS_V4.3>> for the computer.
+The relation between SFRs defined in the <<PP_OS_V4.3>> and SFRs and OEs in the <<BIOPP-Module>> is described below for each security functionality. *Bold SFRs* are those SFRs defined in the <<BIOPP-Module>> for the Biometric System and _italicized SFRs_ are those defined in <<PP_OS_V4.3>> for the TOE.
 
 ===== Authentication Factors
-The authentication factors defined in the <<PP_OS_V4.3>> are Non-Biometric Authentication Factors as defined in the <<BIOPP-Module>>. The computer shall implement an authentication factor as required by the _FIA_UAU.5.1._ These authentication factors are used as an alternative authentication mechanism when the user is rejected by the biometric verification.
+The authentication factors defined in the <<PP_OS_V4.3>> are Non-Biometric Authentication Factors as defined in the <<BIOPP-Module>>. The TOE shall implement an authentication factor as required by the _FIA_UAU.5.1._ These authentication factors are used as an alternative authentication mechanism when the user is rejected by the biometric verification.
 
-The <<BIOPP-Module>> assumes that above requirements are satisfied by the computer as defined in OE.Alternative.
+The <<BIOPP-Module>> assumes that above requirements are satisfied by the TOE as defined in OE.Alternative.
 
 ===== Invocation of the Biometric System
-For any modality selected in _FIA_UAU.5.1_, the computer shall invoke the Biometric System to unlock the computer under the rules specified in _FIA_UAU.5.2_.
+For any modality selected in _FIA_UAU.5.1_, the TOE shall invoke the Biometric System to unlock the TOE under the rules specified in _FIA_UAU.5.2_.
 
-The <<BIOPP-Module>> assumes that above requirements are satisfied by the computer as defined in OE.Authentication.
+The <<BIOPP-Module>> assumes that above requirements are satisfied by the TOE as defined in OE.Authentication.
 
 The Biometric System shall implement a biometric verification mechanism that satisfies SFRs defined in the <<BIOPP-Module>>. This means that same modality shall be selected in *FIA_MBV_EXT.1.1*, and relevant criteria and its error rate shall be specified in *FIA_MBV_EXT.1.2*. If multiple modalities are selected in _FIA_UAU.5.1_, *FIA_MBV_EXT.1* shall be iterated for each modality. The Biometric System shall also enrol all modalities selected as specified in *FIA_MBE.EXT.1*, to assure the quality of samples and templates as specified in *FIA_MBV.EXT.2* and *FIA_MBE.EXT.2*. The Biometric System may also prevent use of artificial presentation attack instruments during the biometric enrolment and verification as specified in *FIA_MBE.EXT.3* and *FIA_MBV.EXT.3*.
 
 ===== Enrolment or Updating a template
 When the user wants to enrol or update a template (such as adding or removing a fingerprint), the <<BIOPP-Module>> requires the user must enter a Non-Biometric Authentication Factor prior to access to the Biometric System as defined in the rules specified in _FIA_UAU.5.2_.
 
-The <<BIOPP-Module>> assumes that above requirements are satisfied by the computer as defined in OE.Authentication.
+The <<BIOPP-Module>> assumes that above requirements are satisfied by the TOE as defined in OE.Authentication.
 
 
 ===== Handling the verification outcome
-The computer shall take appropriate actions after receiving the verification outcome from the Biometric System as defined in _FIA_AFL_EXT.1_. 
+The TOE shall take appropriate actions after receiving the verification outcome from the Biometric System as defined in _FIA_AFL_EXT.1_. 
 
-_FIA_AFL_EXT.1_ defines rules regarding how the authentication factors interact in terms of unsuccessful authentication and actions computer shall take when number of unsuccessful authentication attempts surpass the pre-defined number. The computer also shall apply authentication throttling after failed biometric verification, if configured in _FMT_MOF_EXT.1 (Configure lockout policy for unsuccessful authentication attempts)_.
+_FIA_AFL_EXT.1_ defines rules regarding how the authentication factors interact in terms of unsuccessful authentication and actions TOE shall take when number of unsuccessful authentication attempts surpass the pre-defined number. The TOE also shall apply authentication throttling after failed biometric verification, if configured in _FMT_MOF_EXT.1 (Configure lockout policy for unsuccessful authentication attempts)_.
 
-The <<BIOPP-Module>> assumes that above requirements are satisfied by the computer as defined in OE.Authentication.
+The <<BIOPP-Module>> assumes that above requirements are satisfied by the TOE as defined in OE.Authentication.
 
 ===== Protection of the Biometric System and its biometric data
-The computer shall provide the Secure Execution Environment (e.g. restricted operational environment) so that Biometric System can work securely. This Secure Execution Environment guarantees code and data loaded inside to be protected with respect to confidentiality and integrity. This Secure Execution Environment is out of scope of the Biometric System defined in the <<BIOPP-Module>> and shall be provided by the computer and evaluated based on <<PP_OS_V4.3>>. However, ST author shall explain how such Secure Execution Environment is provided by the computer for the Biometric System, as required by <<BIOSD>>. The computer shall also keep secret any sensitive information regarding the biometric when the computer receives the verification outcome from the Biometric System, as required by _FIA_UAU.7.1_, and provide cryptographic support to encrypt or decrypt biometric data as required by _FCS class_. The computer shall treat source biometric data and values used in the enrolment or verification process (not the final templates) as keying material and critical security parameters according the _FCS_CKM_EXT.4.2_.
+The TOE shall provide the Secure Execution Environment (e.g. restricted operational environment) so that Biometric System can work securely. This Secure Execution Environment guarantees code and data loaded inside to be protected with respect to confidentiality and integrity. This Secure Execution Environment is out of scope of the Biometric System defined in the <<BIOPP-Module>> and shall be provided by the TOE and evaluated based on <<PP_OS_V4.3>>. However, ST author shall explain how such Secure Execution Environment is provided by the TOE for the Biometric System, as required by <<BIOSD>>. The TOE shall also keep secret any sensitive information regarding the biometric when the TOE receives the verification outcome from the Biometric System, as required by _FIA_UAU.7.1_, and provide cryptographic support to encrypt or decrypt biometric data as required by _FCS class_. The TOE shall treat source biometric data and values used in the enrolment or verification process (not the final templates) as keying material and critical security parameters according the _FCS_CKM_EXT.4.2_.
 
-The <<BIOPP-Module>> assumes that above requirements are satisfied by the computer as defined in OE.Protection.
+The <<BIOPP-Module>> assumes that above requirements are satisfied by the TOE as defined in OE.Protection.
 
 However, the Biometric System shall use this Secure Execution Environment correctly to protect biometric data and satisfy the following requirements:
 
@@ -161,17 +161,17 @@ However, the Biometric System shall use this Secure Execution Environment correc
 
 If the Biometric System stores any part of the biometric data outside the Secure Execution Environment, the Biometric System shall protect such data so that any entities running outside the Secure Execution Environment can’t get access to any plaintext biometric data. ST author shall explain what biometric data resides outside the Secure Execution Environment as required by <<BIOSD>> and if no data resides outside the environment, requirements below is implicitly satisfied.
 
-* The Biometric System shall not store any plaintext biometric data outside the Secure Execution Environment. As described in the <<BIOPP-Module>> Section TOE design, the Biometric System can store templates in the enrolment database. The Biometric System shall encrypt templates using cryptographic service provided by the computer within the Secure Execution Environment before storing them in the database, even if the computer storage itself is encrypted by the computer.
+* The Biometric System shall not store any plaintext biometric data outside the Secure Execution Environment. As described in the <<BIOPP-Module>> Section TOE design, the Biometric System can store templates in the enrolment database. The Biometric System shall encrypt templates using cryptographic service provided by the TOE within the Secure Execution Environment before storing them in the database, even if the TOE storage itself is encrypted by the TOE.
 * The Biometric System may overwrite encrypted biometric data in the storage when no longer needed. For example, the Biometric System may overwrite an encrypted template when it is revoked. This is an optional requirement.
 
-The Biometric System shall also protect templates so that only the user of the computer can access them. This means that the Biometric System shall only allow authenticated user by the Password Authentication Factor to access (e.g. add or revoke) the template.
+The Biometric System shall also protect templates so that only the user of the TOE can access them. This means that the Biometric System shall only allow authenticated user by the Password Authentication Factor to access (e.g. add or revoke) the template.
 
 * The Biometric System shall control access to, including adding or revoking, the templates.
 
 The above requirements are defined as *FPT_PBT_EXT.1*, *FPT_BDP_EXT.1*, *FPT_BDP_EXT.2* and *FPT_PBT_EXT.3* in Security Functional Requirements and *FDP_RIP.2* in Optional Requirements in the <<BIOPP-Module>>.
 
 ===== Management of the Biometric System configuration
-The computer shall enable/disable the BAF as required by adding the configuration to _FMT_SMF_EXT.1 [assignment: list of other management functions to be provided by the TSF]_. Any change to the BAF (e.g. adding or revoking templates) requires re-authentication via another authentication factor as specified in _FIA_UAU.5.2_.
+The TOE shall enable/disable the BAF as required by adding the configuration to _FMT_SMF_EXT.1 [assignment: list of other management functions to be provided by the TSF]_. Any change to the BAF (e.g. adding or revoking templates) requires re-authentication via another authentication factor as specified in _FIA_UAU.5.2_.
 
 The <<BIOPP-Module>> assumes that above requirements are satisfied by the TOE environment as defined in OE.Protection.
 
@@ -245,13 +245,13 @@ The evaluator shall take the following additional application notes into account
 
 ===== Application note for EA of AGD_OPE.1
 
-<<BIOPP-Module>> defines the assumptions for the computer that is the operational environment of the biometric system. These assumptions are implicitly satisfied if the computer is successfully evaluated based on <<PP_OS_V4.3>> and the operational guidance doesn’t need to describe the security measures to be followed in order to fulfil the security objectives for the operational environment derived from those assumptions.
+<<BIOPP-Module>> defines the assumptions for the TOE that is the operational environment of the biometric system. These assumptions are implicitly satisfied if the TOE is successfully evaluated based on <<PP_OS_V4.3>> and the operational guidance doesn’t need to describe the security measures to be followed in order to fulfil the security objectives for the operational environment derived from those assumptions.
 
 There is additional application note related to EAs for FIA_MBV_EXT.3 in Section 9.3.2 [Additional application notes for AGD Class] in <<BIOSD>>. The evaluator shall also follow this note depending on the result of the penetration testing for PAD.
 
 ===== Application note for EA of AGD_PRE.1
 
-<<BIOPP-Module>> supposes that the biometric system is fully integrated into the computer and the preparative procedures are unnecessary for <<BIOPP-Module>>. Therefore, AGD_PRE.1 deems satisfied for <<BIOPP-Module>>.
+<<BIOPP-Module>> supposes that the biometric system is fully integrated into the TOE and the preparative procedures are unnecessary for <<BIOPP-Module>>. Therefore, AGD_PRE.1 deems satisfied for <<BIOPP-Module>>.
 
 ==== Class ALC: Life-cycle Support
 

--- a/3_ProtectionProfile/PP_Config-OS.adoc
+++ b/3_ProtectionProfile/PP_Config-OS.adoc
@@ -1,0 +1,333 @@
+= PP-Configuration for Protection Profile for General Purpose Operating Systems and collaborative PP-Module for Biometric enrolment and verification - for unlocking the device - [CFG-OS-BIO]
+:showtitle:
+:toc:
+:table-caption: Table
+:revnumber: 0.5
+:revdate: March 20, 2020
+
+== Acknowledgements
+
+This PP-Configuration was developed by the Biometrics Security international Technical Community (BIO-iTC) with representatives from industry, Government agencies, Common Criteria Test Laboratories, and members of academia.
+
+:sectnums:
+:sectnumlevels: 5
+
+== Introduction
+
+The purpose of a PP-Configuration is to define a Target of Evaluation (TOE) that combines Protection Profiles (PPs) and PP-Modules for various technology types into a single configuration that can be evaluated as a whole. The scope includes the definition of the configuration of a computer (a computer in the terms of the PP-Module) that has biometric enrolment and verification capability. The TOE will be defined by a combination of the components described in <<PP-Configuration Components Statement>>.
+
+The computer for the purposes of this PP-Configuration is a system with a General Purpose Operating System plus a Biometric System. The Biometric System may be directly integrated into the physical computer or an external component that has been linked/paired with the physical computer and for which biometric credentials are linked specifically to the paired computer (i.e. templates registered on computer 1 cannot be used on computer 2).
+
+== PP-Configuration Reference
+
+This PP-Configuration is identified as follows:
+
+* PP-Configuration for Protection Profile for General Purpose Operating Systems and collaborative PP-Module for Biometric enrolment and verification - for unlocking the device - version 0.5, March 20, 2020 - [CFG-OS-BIO]
+
+== PP-Configuration Components Statement
+
+This PP-Configuration includes the following components:
+
+* base PP: Protection Profile for General Purpose Operating Systems, PP_OS_V4.3
+* PP-Module: collaborative PP-Module for Biometric enrolment and verification - for unlocking the device - [BIOPP-Module]
+
+== TOE overview
+
+TOE type, major security features, expected usage of the TOE and non-TOE hardware, software and/or firmware required by the TOE is described in the <<PP_OS_V4.3>> and <<BIOPP-Module>>.
+
+== Consistency Rationale
+
+This section describes consistency rationale between <<PP_OS_V4.3>> and <<BIOPP-Module>> to show that the unions of Security Problem Definition, objectives, and Security Functional Requirement(SFR)s defined in <<PP_OS_V4.3>> and <<BIOPP-Module>> do not lead to a contradiction.
+
+=== Consistency of TOE Type
+
+When the <<BIOPP-Module>> is used to extend <<PP_OS_V4.3>>, the TOE type for the overall TOE is still a general purpose operating system. However, one of the functions of the operating system and computer must be the ability for it to have biometric enrolment and verification capability. The TOE boundary is simply extended to include that functionality.
+
+=== Consistency of Security Problem Definition
+
+The threats, OSPs and assumptions defined by the <<BIOPP-Module>> (see the Sections: Threats, Organizational Security Policies and Assumptions) are consistent with those defined in the <<PP_OS_V4.3>> as follows:
+
+.Consistency Rationale for threats and OSPs
+[cols=".^1,.^1",options="header"]
+|===
+
+|PP-Module Threats/OSPs	
+|Consistency Rationale
+
+|T.Casual_Attack 
+.3+|The threat of zero-effort impostor attempt and presentation attack with related OSPs are specific subsets of the T.LIMITED_PHYSICAL_ACCESS (i.e. impersonate the user authentication mechanisms) threat in the <<PP_OS_V4.3>>.
+|OSP.Enrol
+|OSP.Verification_Error
+
+|OSP.Protection	
+|This OSP is specific subsets of the T.LIMITED_PHYSICAL_ACCESS (i.e. direct and possibly destructive access to its storage media (for biometric data)) threat in the <<PP_OS_V4.3>>.
+
+|===
+
+.Consistency Rationale for Assumptions
+[cols=".^1,.^1",options="header"]
+|===
+|PP-Module Assumptions	    
+|Consistency Rationale
+
+|A.Alternative	
+.3+|All assumptions levied on the operational environment of biometric system (i.e. The computer) are consistent with security requirements in the <<PP_OS_V4.3>>. 
+|A.Authentication
+|A.User
+
+|===
+
+=== Consistency of Objectives
+
+The objectives for the biometric system and its operational environment are consistent with the <<PP_OS_V4.3>> based on the following rationale:
+
+.Consistency Rationale for TOE Objectives
+[cols=".^1,.^1",options="header"]
+|===
+|PP-Module TOE Objectives	
+|Consistency Rationale
+
+|O.BIO_Verification	
+.3+|These TOE Objectives are specific subsets of the O.INTEGRITY objective in the <<PP_OS_V4.3>>. 
+|O.Enrol
+
+|O.Protection	
+|This TOE Objective is specific subset of the O.PROTECTED_STORAGE objective in the <<PP_OS_V4.3>>.
+
+|===
+
+.Consistency Rationale for Environmental Objectives
+[cols=".^1,.^1",options="header"]
+|===
+|PP-Module Environmental Objectives	
+|Consistency Rationale
+
+|OE.Alternative	
+.4+|All Environmental Objectives levied on the operational environment of biometric system (i.e. The computer) are consistent with security requirements in the <<PP_OS_V4.3>>. 
+|OE.Authentication
+|OE.Protection
+|OE.User
+
+|===
+
+=== Consistency of Requirements
+
+The Biometric System (i.e. TSF in the <<BIOPP-Module>>) is comprised of biometric capture sensors and firmware/software that provide functions described in the <<BIOPP-Module>> TOE design. The Biometric System may be integral to the computer or an external (self-contained) device that has been linked/paired with the computer. The Biometric System is invoked by the computer as defined in the <<PP_OS_V4.3>> when user’s biometric characteristics is presented to the sensor. The Biometric System creates and stores the template or compares the features with the stored template and returns the verification outcome to the computer.
+
+The <<BIOPP-Module>> assumes that the computer satisfies SFRs defined in the <<PP_OS_V4.3>> so that the Biometric System can work as specified in the <<BIOPP-Module>>. This section explains which SFRs in the <<PP_OS_V4.3>> are directly relevant to the Biometric System security functionality.
+
+The following rationale identifies several SFRs from <<PP_OS_V4.3>> that are needed to support Biometric System functionality and explains why the unions of SFRs in the <<PP_OS_V4.3>> and <<BIOPP-Module>> do not lead to a contradiction.
+
+==== Relation among SFRs/OEs in the PP_OS_V4.3 and BIOPP-Module
+The relation between SFRs defined in the <<PP_OS_V4.3>> and SFRs and OEs in the <<BIOPP-Module>> is described below for each security functionality. *Bold SFRs* are those SFRs defined in the <<BIOPP-Module>> for the Biometric System and _italicized SFRs_ are those defined in <<PP_OS_V4.3>> for the computer.
+
+===== Authentication Factors
+The authentication factors defined in the <<PP_OS_V4.3>> are Non-Biometric Authentication Factors as defined in the <<BIOPP-Module>>. The computer shall implement an authentication factor as required by the _FIA_UAU.5.1._ These authentication factors are used as an alternative authentication mechanism when the user is rejected by the biometric verification.
+
+The <<BIOPP-Module>> assumes that above requirements are satisfied by the computer as defined in OE.Alternative.
+
+===== Invocation of the Biometric System
+For any modality selected in _FIA_UAU.5.1_, the computer shall invoke the Biometric System to unlock the computer under the rules specified in _FIA_UAU.5.2_.
+
+The <<BIOPP-Module>> assumes that above requirements are satisfied by the computer as defined in OE.Authentication.
+
+The Biometric System shall implement a biometric verification mechanism that satisfies SFRs defined in the <<BIOPP-Module>>. This means that same modality shall be selected in *FIA_MBV_EXT.1.1*, and relevant criteria and its error rate shall be specified in *FIA_MBV_EXT.1.2*. If multiple modalities are selected in _FIA_UAU.5.1_, *FIA_MBV_EXT.1* shall be iterated for each modality. The Biometric System shall also enrol all modalities selected as specified in *FIA_MBE.EXT.1*, to assure the quality of samples and templates as specified in *FIA_MBV.EXT.2* and *FIA_MBE.EXT.2*. The Biometric System may also prevent use of artificial presentation attack instruments during the biometric enrolment and verification as specified in *FIA_MBE.EXT.3* and *FIA_MBV.EXT.3*.
+
+===== Enrolment or Updating a template
+When the user wants to enrol or update a template (such as adding or removing a fingerprint), the <<BIOPP-Module>> requires the user must enter a Non-Biometric Authentication Factor prior to access to the Biometric System as defined in the rules specified in _FIA_UAU.5.2_.
+
+The <<BIOPP-Module>> assumes that above requirements are satisfied by the computer as defined in OE.Authentication.
+
+
+===== Handling the verification outcome
+The computer shall take appropriate actions after receiving the verification outcome from the Biometric System as defined in _FIA_AFL_EXT.1_. 
+
+_FIA_AFL_EXT.1_ defines rules regarding how the authentication factors interact in terms of unsuccessful authentication and actions computer shall take when number of unsuccessful authentication attempts surpass the pre-defined number. The computer also shall apply authentication throttling after failed biometric verification, if configured in _FMT_MOF_EXT.1 (Configure lockout policy for unsuccessful authentication attempts)_.
+
+The <<BIOPP-Module>> assumes that above requirements are satisfied by the computer as defined in OE.Authentication.
+
+===== Protection of the Biometric System and its biometric data
+The computer shall provide the Secure Execution Environment (e.g. restricted operational environment) so that Biometric System can work securely. This Secure Execution Environment guarantees code and data loaded inside to be protected with respect to confidentiality and integrity. This Secure Execution Environment is out of scope of the Biometric System defined in the <<BIOPP-Module>> and shall be provided by the computer and evaluated based on <<PP_OS_V4.3>>. However, ST author shall explain how such Secure Execution Environment is provided by the computer for the Biometric System, as required by <<BIOSD>>. The computer shall also keep secret any sensitive information regarding the biometric when the computer receives the verification outcome from the Biometric System, as required by _FIA_UAU.7.1_, and provide cryptographic support to encrypt or decrypt biometric data as required by _FCS class_. The computer shall treat source biometric data and values used in the enrolment or verification process (not the final templates) as keying material and critical security parameters according the _FCS_CKM_EXT.4.2_.
+
+The <<BIOPP-Module>> assumes that above requirements are satisfied by the computer as defined in OE.Protection.
+
+However, the Biometric System shall use this Secure Execution Environment correctly to protect biometric data and satisfy the following requirements:
+
+* The Biometric System shall process any plaintext biometric data (e.g. capturing biometric characteristic, creating samples, features and templates) for biometric enrolment and verification within the boundary of the Secure Execution Environment. This implies that:
+** Any part of the Biometric System that processes plaintext biometric data shall be within the boundary of the Secure Execution Environment. For example, the biometric capture sensor shall be configured to be within the boundary of the Secure Execution Environment, so that only the Secure Execution Environment can access to the sensor and the data captured. Any software modules that process plaintext biometric data shall run within the boundary of the Secure Execution Environment.
+** Plaintext biometric data shall never be accessible from outside the Secure Execution Environment, and any entities outside the Secure Execution Environment can only access the result of process of biometric data (e.g. success or failure of biometric verification) through the interface provided by the Biometric System.
+
+* The Biometric System shall not transmit any plaintext biometric data outside of the Secure Execution Environment.
+
+If the Biometric System stores any part of the biometric data outside the Secure Execution Environment, the Biometric System shall protect such data so that any entities running outside the Secure Execution Environment can’t get access to any plaintext biometric data. ST author shall explain what biometric data resides outside the Secure Execution Environment as required by <<BIOSD>> and if no data resides outside the environment, requirements below is implicitly satisfied.
+
+* The Biometric System shall not store any plaintext biometric data outside the Secure Execution Environment. As described in the <<BIOPP-Module>> Section TOE design, the Biometric System can store templates in the enrolment database. The Biometric System shall encrypt templates using cryptographic service provided by the computer within the Secure Execution Environment before storing them in the database, even if the computer storage itself is encrypted by the computer.
+* The Biometric System may overwrite encrypted biometric data in the storage when no longer needed. For example, the Biometric System may overwrite an encrypted template when it is revoked. This is an optional requirement.
+
+The Biometric System shall also protect templates so that only the user of the computer can access them. This means that the Biometric System shall only allow authenticated user by the Password Authentication Factor to access (e.g. add or revoke) the template.
+
+* The Biometric System shall control access to, including adding or revoking, the templates.
+
+The above requirements are defined as *FPT_PBT_EXT.1*, *FPT_BDP_EXT.1*, *FPT_BDP_EXT.2* and *FPT_PBT_EXT.3* in Security Functional Requirements and *FDP_RIP.2* in Optional Requirements in the <<BIOPP-Module>>.
+
+===== Management of the Biometric System configuration
+The computer shall enable/disable the BAF as required by adding the configuration to _FMT_SMF_EXT.1 [assignment: list of other management functions to be provided by the TSF]_. Any change to the BAF (e.g. adding or revoking templates) requires re-authentication via another authentication factor as specified in _FIA_UAU.5.2_.
+
+The <<BIOPP-Module>> assumes that above requirements are satisfied by the TOE environment as defined in OE.Protection.
+
+== Conformance claim and conformance statement
+
+=== Common Criteria Conformance claim
+
+This PP-Configuration, <<PP_OS_V4.3>> and <<BIOPP-Module>> are conformant to Common Criteria Version 3.1, Revision 5.
+
+=== The conformance type
+
+To be conformant to this PP-Configuration, an ST must demonstrate Exact Conformance.
+
+=== The Assurance package conformance claim
+
+In order to evaluate a TOE that claims conformance to this PP-Configuration, the evaluator shall evaluate the TOE against the following SARs that are defined in the <<PP_OS_V4.3>>:
+
+[cols=",",options="header",]
+.Assurance Components
+|===
+|Assurance Class 
+|Assurance Components
+
+.7+.^|Security Target (ASE) 
+|Conformance Claims (ASE_CCL.1)
+|Extended Components Definition (ASE_ECD.1)
+|ST Introduction (ASE_INT.1)
+|Security Objectives for the Operational Environment (ASE_OBJ.1)
+|Stated Security Requirements (ASE_REQ.1)
+|Security Problem Definition (ASE_SPD.1)
+|TOE Summary Specification (ASE_TSS.1)
+
+|Development (ADV) 
+|Basic Functional Specification (ADV_FSP.1)
+
+.2+.^|Guidance Documents (AGD) 
+|Operational User Guidance (AGD_OPE.1)
+|Preparative Procedures (AGD_PRE.1)
+
+.3+.^|Life Cycle Support (ALC) 
+|Labeling of the TOE (ALC_CMC.1)
+|TOE CM Coverage (ALC_CMS.1)
+|Timely Security Updates (ALC_TSU_EXT)
+
+|Tests (ATE) 
+|Independent testing - conformance (ATE_IND.1)
+
+|Vulnerability Assessment (AVA) 
+|Vulnerability Survey (AVA_VAN.1)
+
+|===
+
+Note that to fully evaluate the TOE, these SARs shall be applied to the entire TSF and not just the portions described by <<PP_OS_V4.3>> where the SARs are defined.
+
+=== Evaluation methods/activities references statement
+<<PP_OS_V4.3>> and <<BIOSD>> define Evaluation Activities for how to evaluate individual SFRs as they relate to the SARs for ASE_TSS.1, AGD_OPE.1, and ATE_IND.1. If optional requirement FDP_RIP.2 is selected in the <<BIOPP-Module>>, the Evaluation Activities for FCS_CKM_EXT.4 in <<PP_OS_V4.3>> can be applied to FDP_RIP.2.
+
+<<BIOPP-Module>> does not define any SARs beyond those defined within <<PP_OS_V4.3>> to which it can claim conformance. It is important to note that the TOE that is evaluated against <<BIOPP-Module>> is inherently evaluated against <<PP_OS_V4.3>> as well. This means that EAs in Section 5.2 *Security Assurance Requirements* in <<PP_OS_V4.3>> should also applied to <<BIOPP-Module>> with additional application notes or EAs defined in the following Sections.
+
+==== Class ASE: Security Target
+
+<<PP_OS_V4.3>> doesn’t define any EAs and there is no additional EAs for <<BIOPP-Module>>.
+
+==== Class ADV: Development
+
+Same EA defined in <<PP_OS_V4.3>> should also be applied to <<BIOPP-Module>>.
+
+==== Class AGD: Guidance Documentation
+
+The evaluator shall take the following additional application notes into account to perform EAs defined in <<PP_OS_V4.3>>.
+
+===== Application note for EA of AGD_OPE.1
+
+<<BIOPP-Module>> defines the assumptions for the computer that is the operational environment of the biometric system. These assumptions are implicitly satisfied if the computer is successfully evaluated based on <<PP_OS_V4.3>> and the operational guidance doesn’t need to describe the security measures to be followed in order to fulfil the security objectives for the operational environment derived from those assumptions.
+
+There is additional application note related to EAs for FIA_MBV_EXT.3 in Section 9.3.2 [Additional application notes for AGD Class] in <<BIOSD>>. The evaluator shall also follow this note depending on the result of the penetration testing for PAD.
+
+===== Application note for EA of AGD_PRE.1
+
+<<BIOPP-Module>> supposes that the biometric system is fully integrated into the computer and the preparative procedures are unnecessary for <<BIOPP-Module>>. Therefore, AGD_PRE.1 deems satisfied for <<BIOPP-Module>>.
+
+==== Class ALC: Life-cycle Support
+
+The evaluator shall take the following additional application notes into account to perform EAs defined in <<PP_OS_V4.3>> for <<BIOPP-Module>>. There is no application note for EA for ALC_CMS.1 and ALC_TSU_EXT.
+
+===== Application note for EA of ALC_CMC.1
+
+<<BIOPP-Module>> is intended to be used with <<PP_OS_V4.3>> and reference for the computer can be used as the TOE (computer + biometric system) reference only if the reference for the computer also uniquely identifies the biometric system embedded in the computer.
+
+==== Class ATE: Tests
+
+The evaluator shall take the following additional application notes into account to perform EAs defined in <<PP_OS_V4.3>> for <<BIOPP-Module>>.
+
+===== Application note for EA of ATE_IND.1
+
+Same EA should be applied to <<BIOPP-Module>> except optional requirement FIA_MBE_EXT.3 (**Presentation attack detection for biometric enrolment**) and FIA_MBV_EXT.3 (**Presentation attack detection for biometric verification**). The evaluator shall perform EAs defined in Section 6 [Evaluation Activities for PAD testing] in <<BIOSD>> for FIA_MBE_EXT.3 and FIA_MBV_EXT.3.
+
+==== Class AVA: Vulnerability Assessment
+
+The evaluator shall take the following additional application notes into account to perform EAs defined in <<PP_OS_V4.3>> for <<BIOPP-Module>>.
+
+===== Application note for EA of AVA_VAN.1
+
+Same EA should be applied to <<BIOPP-Module>> except optional requirement FIA_MBE_EXT.3 (**Presentation attack detection for biometric enrolment**) and FIA_MBV_EXT.3 (**Presentation attack detection for biometric verification**). The evaluator shall perform EAs defined in Section 6 [Evaluation Activities for PAD testing] in <<BIOSD>> for FIA_MBE_EXT.3 and FIA_MBV_EXT.3.
+
+In evaluating this PP-Configuration, the evaluator shall ensure that all Evaluation Activities for SFRs and SARs are evaluated as part of satisfying the required SARs.
+
+== Related Documents
+
+**Common Criteria**footnote:[For details see http://www.commoncriteriaportal.org/]
+
+[cols="1,3",]
+|===
+|[#CC1]#[CC1]# |Common Criteria for Information Technology Security Evaluation, +
+Part 1: Introduction and General Model, +
+CCMB-2017-04-001, Version 3.1 Revision 5, April 2017.
+|[#CC2]#[CC2]# |Common Criteria for Information Technology Security Evaluation, +
+Part 2: Security Functional Components, +
+CCMB-2017-04-002, Version 3.1 Revision 5, April 2017.
+|[#CC3]#[CC3]# |Common Criteria for Information Technology Security Evaluation, +
+Part 3: Security Assurance Components, +
+CCMB-2017-04-003, Version 3.1 Revision 5, April 2017.
+|[#CEM]#[CEM]# |Common Methodology for Information Technology Security Evaluation, +
+Evaluation Methodology, +
+CCMB-2017-04-004, Version 3.1 Revision 5, April 2017.
+|[#addenda]#[addenda]# |CC and CEM addenda, +
+Exact Conformance, Selection-Based SFRs, Optional SFRs, +
+Version 0.5, May 2017.
+|===
+
+*Protection Profiles*
+
+[cols="1,3",]
+|===
+|[#PP_OS_V4.3]#[PP_OS_V4.3]# 
+|Protection Profile for General Purpose Operating Systems, FUTURE DATE, Version:4.3
+
+|[#BIOPP-Module]#[BIOPP-Module]# 
+|collaborative PP-Module for Biometric enrolment and verification - for unlocking the device -, March 13, 2020, Version 0.95 - [BIOPP-Module]
+
+|[#BIOSD]#[BIOSD]#
+|Supporting Document Mandatory Technical Document: Evaluation Activities for collaborative PP-Module for Biometric enrolment and verification - for unlocking the device -, March 13, 2020, Version 0.95 - [BIOSD]
+
+|===
+
+== Revision History
+
+[cols=".^1,.^2,3",options="header",]
+.Revision history
+|===
+|Version 
+|Date 
+|Description
+
+|0.5 
+|March 20, 2020 
+|First draft based on PP-Config for MDFPP
+
+|===


### PR DESCRIPTION
Initial updated GPOS PP-Config.

This is based on the latest MDF version.

The main concern is section 5.4.1.5 which talks about the SEE. There isn't an SEE or equivalent required for the OS (which makes sense as it is not hardware). This could mean we can't make this work without more than some basic edits to the PP (i.e. auth edits to allow biometrics).

One possible method though would be to only allow approval based on some expectation that the biometric subsystem is isolated hardware and does not use the AP of the computer. So a self-contained biometric system using its own processor (I may say it could allow storage on the disk if it encrypts it first, like a TEE), would be the only acceptable devices that could be used here. A USB (or maybe BT) device would work, but not one where it handed everything off to the OS to process and store.

I'm not sure this will work, it may be layering too many requirements on how this should work.

I'm sending this version to Mike Grimm at Microsoft (since they are the company that validates end user OS, I don't know that Oracle would care about this topic).