### PR TITLE
Found "enroll"

### DIFF
--- a/Protection Profile/BiocPP.adoc
+++ b/Protection Profile/BiocPP.adoc
@@ -70,7 +70,7 @@ Computer::
 	A self-contained device which is composed of a hardware platform and its system software (operating system and applications). The device is typically some sort of general purpose computing platform, such as a laptop, tablet or smartphone that is designed to be portable (though this is not required). 
 Computer User (User)::
 	The individual authorized to physically control and operate the Computer, usually the device owner. This person is responsible for configuring the TOE.
-Failure-To-Enroll Rate (FTE)::
+Failure-To-Enrol Rate (FTE)::
 	Proportion of the population for whom the system fails to complete the enrolment process.
 False Accept Rate (FAR)::
 	Proportion of verification transactions with wrongful biometric claims of identity that are incorrectly confirmed.


### PR DESCRIPTION
The language for the PP-Module has used "enrol" but the definitions list has "Failure-to-Enroll". Given the standard usage of one "l", this should be edited.

This can wait until the next update and does not need to be made into an interpretation, but should be fixed in the next major release.