### PR TITLE
FPT_BDP_EXT updates

### DIFF
--- a/Protection Profile/BiocPP.adoc
+++ b/Protection Profile/BiocPP.adoc
@@ -449,7 +449,7 @@ Target error rates defined in SFR shall be evaluated based on <<BIOSD>>. Normall
 ==== Protection of the TSF (FPT)
 ===== FPT_BDP_EXT.1 Biometric data processing [[FPT_BDP_EXT.1]]
 
-*FPT_BDP_EXT.1.1* Processing of plaintext biometric data used to generate templates and perform sample matching shall be hardware-isolated from the OS on the TSF in runtime.
+*FPT_BDP_EXT.1.1* Processing of plaintext biometric data used to generate templates and perform sample comparisons shall be hardware-isolated from the OS on the TSF in runtime.
 
 *Application Note {counter:remark_count}*:: If biometric data processing occurs in a separate execution environment on the same Application Processor as the OS, the biometric data must be cleared from RAM immediately after use, and at least, must be wiped with the device is locked.
 

--- a/Protection Profile/BiocPP.adoc
+++ b/Protection Profile/BiocPP.adoc
@@ -451,7 +451,7 @@ Target error rates defined in SFR shall be evaluated based on <<BIOSD>>. Normall
 
 *FPT_BDP_EXT.1.1* Processing of plaintext biometric data used to generate templates and perform sample comparisons shall be hardware-isolated from the OS on the TSF in runtime.
 
-*Application Note {counter:remark_count}*:: If biometric data processing occurs in a separate execution environment on the same Application Processor as the OS, the biometric data must be cleared from RAM immediately after use, and at least, must be wiped with the device is locked.
+*Application Note {counter:remark_count}*:: If biometric data processing occurs in a separate execution environment on the same Application Processor as the OS, the biometric data must be cleared from RAM immediately after use, and at least, must be wiped when the device is locked.
 
 ===== FPT_PBT_EXT.1 Protection of biometric template [[FPT_PBT_EXT.1]]
 

--- a/Protection Profile/BiocPP.adoc
+++ b/Protection Profile/BiocPP.adoc
@@ -36,7 +36,7 @@ Although the PP-Module and Supporting Document <<BIOSD>> may contain minor edito
 - [#CC3]#[CC3]#	Common Criteria for Information Technology Security Evaluation, Part 3: Security Assurance Components, CCMB-2017-04-003, Version 3.1 Revision 5, April 2017.
 - [#CEM]#[CEM]#	Common Methodology for Information Technology Security Evaluation, Evaluation Methodology, CCMB-2017-04-004, Version 3.1 Revision 5, April 2017.
 - [#addenda]#[addenda]#	CC and CEM addenda, Exact Conformance, Selection-Based SFRs, Optional SFRs, Version 0.5, May 2017.
-- [#PP_GPOS]#[PP_GPOS]# Protection Profile for General Purpose Operating Systems.
+- [#PP_OS]#[PP_OS]# Protection Profile for General Purpose Operating Systems.
 - [#PP_MD_V3.3]#[PP_MD_V3.3]# Protection Profile for Mobile Device Fundamentals, Version:3.3.
 - [#PPC-MDF]#[PPC-MDF]# PP-Configuration for Protection Profile for Mobile Device Fundamentals and collaborative PP-Module for Biometric enrolment and verification - for unlocking the device -, {revdate}, Version 1.0 [CFG-MDF-BIO].
 - [#BIOSD]#[BIOSD]# Supporting Document Mandatory Technical Document: Evaluation Activities for collaborative PP-Module for Biometric enrolment and verification - for unlocking the device -, {revdate}, Version 1.1 - [BIOSD].
@@ -68,7 +68,7 @@ Biometric Enrolment::
 Biometric Probe::
 	Biometric sample or biometric feature set input to an algorithm for use as the subject of biometric comparison to a biometric template(s).
 Computer::
-	A self-contained device which is composed of a hardware platform and its system software (operating system and applications). The device is typically some sort of general purpose computing platform, such as a laptop, tablet or smartphone that is designed to be portable (though this is not required). _In this version, the term Computer is used as a synonym for Mobile device. However, in the future version, this PP-Module will be updated to allow to use with the latest version of <<PP_GPOS>> and this italic text will also be removed._
+	A self-contained device which is composed of a hardware platform and its system software (operating system and applications). The device is typically some sort of general purpose computing platform, such as a laptop, tablet or smartphone that is designed to be portable (though this is not required). _In this version, the term Computer is used as a synonym for Mobile device. However, in the future version, this PP-Module will be updated to allow to use with the latest version of <<PP_OS>> and this italic text will also be removed._
 Computer User (User)::
 	The individual authorized to physically control and operate the Computer, usually the device owner. This person is responsible for configuring the TOE.
 Failure-To-Enrol Rate (FTE)::
@@ -95,7 +95,7 @@ Presentation Attack Detection (PAD)::
 	Automated determination of a presentation attack.
 (Biometric) Sample::
 	User’s biometric measures as output by the data capture subsystem of the TOE.
-Secure Execution Environment::
+Separate Execution Environment (SEE)::
 	An operating environment separate from the main Computer operating system. Access to this environment is highly restricted and may be made available through special processor modes, separate security processors or a combination to provide this separation.
 Similarity Score::
 	Measure of the similarity between features derived from a sample and a stored template, or a measure of how well these features fit a user’s reference model.
@@ -157,8 +157,8 @@ Zero-effort Impostor Attempt::
 |Public Release
 
 |1.1
-|
-|Incorporated TDs and NIAP comments for PP_MD integration
+|TBD, 2021
+|Incorporated TDs and NIAP comments for PP_MD_V3.3 integration
 
 |===
 
@@ -173,7 +173,7 @@ Zero-effort Impostor Attempt::
 This PP-Module is intended for use with the following Base-PP:
 Protection Profile for Mobile Device Fundamentals <<PP_MD_V3.3>>.
 
-This Base-PP is valid because biometric enrolment and verification may be a specific type of stand-alone software application or a built-in component of a computer. The biometric enrolment and verification functionality defined by this PP-Module will rely on the Base-PP. The biometric enrolment and verification functionality defined by this PP-Module will rely on the Base-PP and Section <<<<PP_MD_V3.3>> Security Functional Requirements Direction>> of this PP-Module describes the relevant functionality for the Base-PP, including specific selections, assignments, or inclusion of optional requirements that must be made as needed to support the biometric enrolment and verification functionality.
+This Base-PP is valid because biometric enrolment and verification may be a specific type of stand-alone software application or a built-in component of a computer. The biometric enrolment and verification functionality defined by this PP-Module will rely on the Base-PP. The biometric enrolment and verification functionality defined by this PP-Module will rely on the Base-PP and Section <<PP_MD_V3.3 Security Functional Requirements Direction>> of this PP-Module describes the relevant functionality for the Base-PP, including specific selections, assignments, or inclusion of optional requirements that must be made as needed to support the biometric enrolment and verification functionality.
 
 === TOE Overview
 ==== TOE main security features
@@ -212,7 +212,7 @@ The TOE is reliant on the computer itself to provide overall security of the sys
 
 * Providing the NBAF to support user authentication and management of the TOE security function
 * Invoking the TOE to enrol and verify the user and take appropriate actions based on the decision of the TOE
-* Providing the Secure Execution Environment that guarantees the TOE and its data to be protected with respect to confidentiality and integrity
+* Providing the Separate Execution Environment that guarantees the TOE and its data to be protected with respect to confidentiality and integrity
 
 The specification of the above security functions is out of scope of this PP-Module and are part of the base PP. 
  
@@ -310,18 +310,18 @@ Requirements to provide a biometric enrolment mechanism are defined in FIA_MBE_E
 *Application Note {counter:remark_count}*:: In this PP-Module, relevant criteria are FAR/FMR and FRR/FNMR. Corresponding error rates are specified in FIA_MBV_EXT.1.
 
 [[O.Protection]]O.Protection::
-The TOE shall protect biometric data using the Secure Execution Environment provided by the TOE environment during runtime and storage.
+The TOE shall protect biometric data using the Separate Execution Environment provided by the TOE environment during runtime and storage.
 
 SFR Rationale:
 
-Requirements to control access to the template defined in FPT_PBT_EXT.1. FPT_BDP_EXT.1, FPT_BDP_EXT.2 and FPT_BDP_EXT.3 require the TOE to protect the biometric data with support from the TOE environment. Optional requirements to protect the residual biometric data are defined as FDP_RIP.2 in <<Optional Requirements>>.
+Requirements to control access to the template defined in FPT_PBT_EXT.1. FPT_BDP_EXT.1, FPT_KST_EXT.1 and FPT_KST_EXT.2 require the TOE to protect the biometric data with support from the TOE environment. Optional requirements to protect the residual biometric data are defined as FDP_RIP.2 in <<Optional Requirements>>.
 
 *Application Note {counter:remark_count}*:: The TOE and TOE environment (i.e., the computer) satisfy relevant requirements defined in this PP-Module and base PP respectively to protect biometric data.
 
 === Security Objectives for the Operational Environment
 
 [[OE.Protection]]OE.Protection::
-The TOE environment shall provide a Secure Execution Environment to protect the TOE, the TOE configuration and biometric data during runtime and storage.
+The TOE environment shall provide a Separate Execution Environment to protect the TOE, the TOE configuration and biometric data during runtime and storage.
 
 *Application Note {counter:remark_count}*:: The TOE and TOE environment (i.e. the computer) satisfy relevant requirements defined in this PP-Module and base PP respectively to protect biometric data.
 
@@ -361,11 +361,11 @@ The following conventions are used for the completion of operations:
 
 Extended SFRs are identified by having a label “EXT” at the end of the SFR name.
 
-=== <<PP_MD_V3.3>> Security Functional Requirements Direction
+=== PP_MD_V3.3 Security Functional Requirements Direction
 
 In a PP-Configuration that includes the <<PP_MD_V3.3>>, the biometric enrolment and verification is expected to rely on some of the security functions implemented by the computer as a whole and evaluated against the Base-PP. In this case, the following sections describe any modifications that the ST author must make to the SFRs defined in the Base-PP in addition to what is mandated by <<TOE Security Functional Requirements>>. 
 
-Full evaluation activities are not repeated in the <<BIOSD>> for the requirements in this section that are references to the <<PP_MD_V3.3>>; only the additional testing needed to supplement whathas already been captured in the <<PP_MD_V3.3>> is included in the <<BIOSD>>
+Full evaluation activities are not repeated in the <<BIOSD>> for the requirements in this section that are references to the <<PP_MD_V3.3>>; only the additional testing needed to supplement what has already been captured in the <<PP_MD_V3.3>> is included in the <<BIOSD>>
 
 [NOTE]
 ====
@@ -376,10 +376,17 @@ TODO: Need to add additional EAs for modified and additional SFR to <<BIOSD>>
 
 The SFRs listed in this section are defined in the <<PP_MD_V3.3>> and relevant to the secure operation of the biometric enrolment and verification. It is necessary for the ST author to complete selections and/or assignments for these SFRs in a specific manner in order to ensure that the functionality provided by the mobile device is consistent with the functionality required by the biometric enrolment and verification in order for it to conform to this PP-Module.
 
-[NOTE]
-====
-TODO: Need to add modified SFRs here 
-====
+===== FPT_KST_EXT.1 Key Storage [[FPT_KST_EXT.1]]
+
+*FPT_KST_EXT.1.1*:: The TSF shall not store any plaintext key material *and biometric data* in readable non-volatile memory.
+
+*Application Note {counter:remark_count}*:: This SFR is functionally identical to what is defined in the <<PP_MD_V3.3>> with the addition of biometric data as key materials to be protected. Plaintext biometric data to be protected includes any data used to generate templates and perform sample matching from the initial data capture to the match results.
+
+===== FPT_KST_EXT.2 No Key Transmission [[FPT_KST_EXT.2]]
+
+*FPT_KST_EXT.2.1*:: The TSF shall not transmit any plaintext key material *or biometric data* outside the security boundary of the TOE.
+
+*Application Note {counter:remark_count}*:: This SFR is functionally identical to what is defined in the <<PP_MD_V3.3>> with the addition of biometric data as plaintext key materials that must not be transmitted off-device.
 
 ==== Additional SFRs
 
@@ -439,21 +446,9 @@ Target error rates defined in SFR shall be evaluated based on <<BIOSD>>. Normall
 ==== Protection of the TSF (FPT)
 ===== FPT_BDP_EXT.1 Biometric data processing [[FPT_BDP_EXT.1]]
 
-*FPT_BDP_EXT.1.1* The TSF shall process any plaintext biometric data used to generate templates and perform sample matching within the security boundary of the Secure Execution Environment.
+*FPT_BDP_EXT.1.1* Processing of plaintext biometric data used to generate templates and perform sample matching shall be hardware-isolated from the OS on the TSF in runtime.
 
-*Application Note {counter:remark_count}*:: The Consistency Rationale in the appropriate PP-Configuration explains how the TOE in cooperation with its environment protects biometric data in detail.
-
-===== FPT_BDP_EXT.2 Biometric data transmission [[FPT_BDP_EXT.2]]
-
-*FPT_BDP_EXT.2.1* The TSF shall not transmit any plaintext biometric data outside the security boundary of the Secure Execution Environment.
-
-*Application Note {counter:remark_count}*:: The Consistency Rationale in the appropriate PP-Configuration explains how the TOE in cooperation with its environment protects biometric data in detail.
-
-===== FPT_BDP_EXT.3 Biometric data storage [[FPT_BDP_EXT.3]]
-
-[[FPT_BDP_EXT.3.1]]*FPT_BDP_EXT.3.1* The TSF shall not store any plaintext biometric data outside the security boundary of the Secure Execution Environment.
-
-*Application Note {counter:remark_count}*:: The Consistency Rationale in the appropriate PP-Configuration explains how the TOE in cooperation with its environment protects biometric data in detail.
+*Application Note {counter:remark_count}*:: If biometric data processing occurs in a separate execution environment on the same Application Processor as the OS, the biometric data must be cleared from RAM immediately after use, and at least, must be wiped with the device is locked.
 
 ===== FPT_PBT_EXT.1 Protection of biometric template [[FPT_PBT_EXT.1]]
 
@@ -579,7 +574,7 @@ TODO: above text should be modified because we delete assumptions and OE.
 ====
 
 ===== Protection of the Biometric System and its biometric data
-The mobile device shall provide the Secure Execution Environment (e.g. restricted operational environment) so that Biometric System can work securely. This Secure Execution Environment guarantees code and data loaded inside to be protected with respect to confidentiality and integrity. This Secure Execution Environment is out of scope of the Biometric System defined in this PP-Module and shall be provided by the mobile device and evaluated based on <<PP_MD_V3.3>>. However, ST author shall explain how such Secure Execution Environment is provided by the mobile device for the Biometric System, as required by <<BIOSD>>. The mobile device shall also keep secret any sensitive information regarding the biometric when the mobile device receives the verification outcome from the Biometric System, as required by _FIA_UAU.7.1_, and provide cryptographic support to encrypt or decrypt biometric data as required by _FCS class_. The mobile device shall treat source biometric data and values used in the enrolment or verification process (not the final templates) as keying material and critical security parameters according the _FCS_CKM_EXT.4.2_.
+The mobile device shall provide the Separate Execution Environment (e.g. restricted operational environment) so that Biometric System can work securely. This Separate Execution Environment guarantees code and data loaded inside to be protected with respect to confidentiality and integrity. This Separate Execution Environment is out of scope of the Biometric System defined in this PP-Module and shall be provided by the mobile device and evaluated based on <<PP_MD_V3.3>>. However, ST author shall explain how such Separate Execution Environment is provided by the mobile device for the Biometric System, as required by <<BIOSD>>. The mobile device shall also keep secret any sensitive information regarding the biometric when the mobile device receives the verification outcome from the Biometric System, as required by _FIA_UAU.7.1_, and provide cryptographic support to encrypt or decrypt biometric data as required by _FCS class_. The mobile device shall treat source biometric data and values used in the enrolment or verification process (not the final templates) as keying material and critical security parameters according the _FCS_CKM_EXT.4.2_.
 
 This PP-Module assumes that above requirements are satisfied by the mobile device as defined in OE.Protection.
 
@@ -588,17 +583,17 @@ This PP-Module assumes that above requirements are satisfied by the mobile devic
 TODO: above text should be modified. 
 ====
 
-However, the Biometric System shall use this Secure Execution Environment correctly to protect biometric data and satisfy the following requirements:
+However, the Biometric System shall use this Separate Execution Environment correctly to protect biometric data and satisfy the following requirements:
 
-* The Biometric System shall process any plaintext biometric data (e.g. capturing biometric characteristic, creating samples, features and templates) for biometric enrolment and verification within the boundary of the Secure Execution Environment. This implies that:
-** Any part of the Biometric System that processes plaintext biometric data shall be within the boundary of the Secure Execution Environment. For example, the biometric capture sensor shall be configured to be within the boundary of the Secure Execution Environment, so that only the Secure Execution Environment can access to the sensor and the data captured. Any software modules that process plaintext biometric data shall run within the boundary of the Secure Execution Environment.
-** Plaintext biometric data shall never be accessible from outside the Secure Execution Environment, and any entities outside the Secure Execution Environment can only access the result of process of biometric data (e.g. success or failure of biometric verification) through the interface provided by the Biometric System.
+* The Biometric System shall process any plaintext biometric data (e.g. capturing biometric characteristic, creating samples, features and templates) for biometric enrolment and verification within the boundary of the Separate Execution Environment. This implies that:
+** Any part of the Biometric System that processes plaintext biometric data shall be within the boundary of the Separate Execution Environment. For example, the biometric capture sensor shall be configured to be within the boundary of the Separate Execution Environment, so that only the Separate Execution Environment can access to the sensor and the data captured. Any software modules that process plaintext biometric data shall run within the boundary of the Separate Execution Environment.
+** Plaintext biometric data shall never be accessible from outside the Separate Execution Environment, and any entities outside the Separate Execution Environment can only access the result of process of biometric data (e.g. success or failure of biometric verification) through the interface provided by the Biometric System.
 
-* The Biometric System shall not transmit any plaintext biometric data outside of the Secure Execution Environment.
+* The Biometric System shall not transmit any plaintext biometric data outside of the Separate Execution Environment.
 
-If the Biometric System stores any part of the biometric data outside the Secure Execution Environment, the Biometric System shall protect such data so that any entities running outside the Secure Execution Environment can not get access to any plaintext biometric data. ST author shall explain what biometric data resides outside the Secure Execution Environment as required by <<BIOSD>> and if no data resides outside the environment, requirements below is implicitly satisfied.
+If the Biometric System stores any part of the biometric data outside the Separate Execution Environment, the Biometric System shall protect such data so that any entities running outside the Separate Execution Environment can not get access to any plaintext biometric data. ST author shall explain what biometric data resides outside the Separate Execution Environment as required by <<BIOSD>> and if no data resides outside the environment, requirements below is implicitly satisfied.
 
-* The Biometric System shall not store any plaintext biometric data outside the Secure Execution Environment. As described in this PP-Module Section TOE design, the Biometric System can store templates in the enrolment database. The Biometric System shall encrypt templates using cryptographic service provided by the mobile device within the Secure Execution Environment before storing them in the database, even if the mobile device storage itself is encrypted by the mobile device.
+* The Biometric System shall not store any plaintext biometric data outside the Separate Execution Environment. As described in this PP-Module Section TOE design, the Biometric System can store templates in the enrolment database. The Biometric System shall encrypt templates using cryptographic service provided by the mobile device within the Separate Execution Environment before storing them in the database, even if the mobile device storage itself is encrypted by the mobile device.
 
 * The Biometric System may overwrite encrypted biometric data in the storage when no longer needed. For example, the Biometric System may overwrite an encrypted template when it is revoked. This is an optional requirement.
 
@@ -606,7 +601,7 @@ The Biometric System shall also protect templates so that only the user of the m
 
 * The Biometric System shall control access to, including adding or revoking, the templates.
 
-The above requirements are defined as *FPT_PBT_EXT.1*, *FPT_BDP_EXT.1*, *FPT_BDP_EXT.2* and *FPT_PBT_EXT.3* in Security Functional Requirements and *FDP_RIP.2* in Optional Requirements in this PP-Module.
+The above requirements are defined as *FPT_PBT_EXT.1*, *FPT_BDP_EXT.1*, *FPT_KST_EXT.1* and *FPT_KST_EXT.2* in Security Functional Requirements and *FDP_RIP.2* in Optional Requirements in this PP-Module.
 
 ===== Management of the Biometric System configuration
 The mobile device shall enable/disable the BAF as required by _FMT_SMF_EXT.1 (Management function 23)_, and revoke the BAF as _FMT_SMF_EXT.1 (Management Function 46)_. Any change to the BAF (e.g. adding or revoking templates) requires re-authentication via the Password Authentication Factor as required by _FIA_UAU.6.2_.
@@ -834,29 +829,20 @@ This component defines the requirements for the TSF to be able to protect plaint
 .Component levelling
 [ditaa,"FPT_BDP_EXT.png"]
 ....
-                                                    +---+
-                                                 +->| 1 |
-                                                 |  +---+
-    +-----------------------------------------+  |
-    |                                         |  |  +---+
-    | FPT_BDP_EXT  Biometric data processing  +--+->| 2 |
-    |                                         |  |  +---+
-    +-----------------------------------------+  |
-                                                 |  +---+
-                                                 +->| 3 |
-                                                    +---+
+
+    +-----------------------------------------+ 
+    |                                         |     +---+
+    | FPT_BDP_EXT  Biometric data processing  +--+->| 1 |
+    |                                         |     +---+
+    +-----------------------------------------+ 
 ....
  
-FPT_BDP_EXT.1 Biometric data processing requires the TSF to process plaintext biometric data within the security boundary of the Secure Execution Environment.
+FPT_BDP_EXT.1 Biometric data processing requires the TSF to process plaintext biometric data within the in a separate execution environment from the OS.
 
-FPT_BDP_EXT.2 Biometric data transmission requires the TSF not to transmit plaintext biometric data outside the security boundary of the Secure Execution Environment.
-
-FPT_BDP_EXT.3 Biometric data storage requires the TSF not to store plaintext biometric data outside the security boundary of the Secure Execution Environment.
-
-===== Management: FPT_BDP_EXT.1, FPT_BDP_EXT.2, FPT_BDP_EXT.3
+===== Management: FPT_BDP_EXT.1
 There are no management activities foreseen.
 
-===== Audit: FPT_BDP_EXT.1, FPT_BDP_EXT.2, FPT_BDP_EXT.3
+===== Audit: FPT_BDP_EXT.1
 There are no auditable events foreseen.
 
 ===== FPT_BDP_EXT.1 Biometric data processing
@@ -864,22 +850,7 @@ Hierarchical to: No other components
 
 Dependencies: No dependencies
 
-*FPT_BDP_EXT.1.1* The TSF shall process any plaintext biometric data used to generate templates and perform sample matching within the security boundary of the Secure Execution Environment.
-
-===== FPT_BDP_EXT.2 Biometric data transmission
-Hierarchical to: 	No other components
-
-Dependencies: 	No dependencies
-
-*FPT_BDP_EXT.2.1* The TSF shall not transmit any plaintext biometric data outside the security boundary of the Secure Execution Environment.
-
-===== FPT_BDP_EXT.3 Biometric data storage
-
-Hierarchical to: 	No other components
-
-Dependencies: 	No dependencies
-
-*FPT_BDP_EXT.3.1* The TSF shall not store any plaintext biometric data outside the security boundary of the Secure Execution Environment.
+*FPT_BDP_EXT.1.1* Processing of plaintext biometric data used to generate templates and perform sample matching shall be hardware-isolated from the OS on the TSF in runtime.
 
 ==== Protection of biometric template (FPT_PBT_EXT)
 *Family Behaviour*

--- a/Protection Profile/BiocPP.adoc
+++ b/Protection Profile/BiocPP.adoc
@@ -383,7 +383,7 @@ The SFRs listed in this section are defined in the <<PP_MD_V3.3>> and relevant t
 
 *FPT_KST_EXT.1.1*:: The TSF shall not store any plaintext key material *and biometric data* in readable non-volatile memory.
 
-*Application Note {counter:remark_count}*:: This SFR is functionally identical to what is defined in the <<PP_MD_V3.3>> with the addition of biometric data as key materials to be protected. Plaintext biometric data to be protected includes any data used to generate templates and perform sample matching from the initial data capture to the match results.
+*Application Note {counter:remark_count}*:: This SFR is functionally identical to what is defined in the <<PP_MD_V3.3>> with the addition of biometric data as key materials to be protected. Plaintext biometric data to be protected includes any data used to generate templates or perform sample comparisons from the initial data capture, as well as the comparison score.
 
 ===== FPT_KST_EXT.2 No Key Transmission [[FPT_KST_EXT.2]]
 

--- a/Protection Profile/BiocPP.adoc
+++ b/Protection Profile/BiocPP.adoc
@@ -12,9 +12,12 @@
 :iTC-longame: Biometrics Security
 :iTC-shortname: BIO-iTC
 
+:sectnums!:
 
 == Acknowledgements
 This collaborative Protection Profile module (PP-Module) was developed by the {iTC-longame} international Technical Community ({iTC-shortname}) with representatives from industry, Government agencies, Common Criteria Test Laboratories, and members of academia.
+
+:sectnums:
 
 == Preface
 
@@ -314,7 +317,7 @@ The TOE shall protect biometric data using the Separate Execution Environment pr
 
 SFR Rationale:
 
-Requirements to control access to the template defined in FPT_PBT_EXT.1. FPT_BDP_EXT.1, FPT_KST_EXT.1 and FPT_KST_EXT.2 require the TOE to protect the biometric data with support from the TOE environment. Optional requirements to protect the residual biometric data are defined as FDP_RIP.2 in <<Optional Requirements>>.
+Requirements to control access to the template defined in FPT_PBT_EXT.1. FPT_BDP_EXT.1, FPT_KST_EXT.1 (refined from <<PP_MD_V3.3>>) and FPT_KST_EXT.2 (refined from <<PP_MD_V3.3>>) require the TOE to protect the biometric data with support from the TOE environment. Optional requirements to protect the residual biometric data are defined as FDP_RIP.2 in <<Optional Requirements>>.
 
 *Application Note {counter:remark_count}*:: The TOE and TOE environment (i.e., the computer) satisfy relevant requirements defined in this PP-Module and base PP respectively to protect biometric data.
 

--- a/Supporting Documents/BS_SD.adoc
+++ b/Supporting Documents/BS_SD.adoc
@@ -655,15 +655,15 @@ The evaluator can pass this EA only if the evaluator confirms that:
 
 The evaluator shall report the summary of result of EA defined above, especially how the evaluator reaches the Pass/Fail judgement based on the Pass/Fail criteria.
 
-== Evaluation Activities for PP_MD Requirements
+== Evaluation Activities for PP_MD_V3.3 Requirements
 In addition to the EAs required by the base PP, the evaluator shall perform the following additional EAs to ensure that the base PP's security functionaltiy is maintained by the addition of the PP-Module.
 
 === Modified SFRs from the base PP
 ==== Protection of the TSF (FPT)
 ===== Key Storage (FPT_KST)
-*FPT_KST_EXT.1*:: Refer to the EA for FPT_KST_EXT.1 in the PP_MD including biometric data as part of the plaintext key materials.
+*FPT_KST_EXT.1*:: Refer to the EA for FPT_KST_EXT.1 in the <<PP_MD_V3.3>> including biometric data as part of the plaintext key materials.
 
-*FPT_KST_EXT.2*:: Refer to the EA for FPT_KST_EXT.2 in the PP_MD including biometric data as part of the plaintext key materials.
+*FPT_KST_EXT.2*:: Refer to the EA for FPT_KST_EXT.2 in the <<PP_MD_V3.3>> including biometric data as part of the plaintext key materials.
 
 == Evaluation Activities for Selection-Based Requirements 
 

--- a/Supporting Documents/BS_SD.adoc
+++ b/Supporting Documents/BS_SD.adoc
@@ -5,8 +5,8 @@
 :table-caption: Table
 :imagesdir: images
 :icons: font
-:revnumber: 1.0.1
-:revdate: November 10, 2020
+:revnumber: 1.1
+:revdate: TBD, 2021
 :xrefstyle: full
 :doctype: book
 
@@ -68,6 +68,10 @@ Biometric Security international Technical Community (BIO-iTC)
 |1.0.1
 |November 10, 2020
 |Technical Decision BIO0002
+
+|1.1
+|TBD, 2021
+|Incorporated TDs and NIAP comments for PP_MD_V3.3 integration
 
 |===
 
@@ -179,7 +183,7 @@ For definitions of standard CC terminology see <<CC1>>. For definitions of biome
 |Supporting Document
 
 |*SEE* 
-|Secure Execution Environment
+|Separate Execution Environment
 
 |*SFR* 
 |Security Functional Requirement
@@ -531,11 +535,11 @@ The evaluator shall report the summary of the result of EA defined above, especi
 
 ===== Objective of the EA
 
-<<BIOPP-Module>> assumes that the computer provides the Secure Execution Environment (SEE), an operating environment separate from the main computer operating system. Access to the SEE is highly restricted and may be made available through special processor modes, separate security processors or a combination to provide this separation.
+<<BIOPP-Module>> assumes that the computer provides the Separate Execution Environment (SEE), an operating environment separate from the main computer operating system. Access to the SEE is highly restricted and may be made available through special processor modes, separate security processors or a combination to provide this separation.
 
-Evaluation of this SEE is out of scope of <<BIOPP-Module>> and the evaluator does not need to evaluate this environment itself. However, the evaluator shall examine that the TOE processes any plaintext biometric data within the security boundary of the SEE. The SEE is responsible for preventing any entities outside the environment from accessing plaintext biometric data.
+Evaluation of this SEE is out of scope of <<BIOPP-Module>> and the evaluator does not need to evaluate this environment itself. However, the evaluator shall examine that the TOE processes any plaintext biometric data within the boundary of the SEE. The SEE is responsible for preventing any entities outside the environment from accessing plaintext biometric data.
 
-FPT_BDP_EXT.1 applies to plaintext biometric data being processed during biometric enrolment and verification. Protection of transmitted and stored biometric data is out of scope of this EA and covered by FPT_BDP_EXT.2 and FPT_BDP_EXT.3 respectively.
+FPT_BDP_EXT.1 applies to plaintext biometric data being processed during biometric enrolment and verification. Protection of transmitted and stored biometric data is out of scope of this EA and covered by FPT_KST_EXT.1 and FPT_KST_EXT.2 respectively.
 
 ===== Dependency
 
@@ -580,98 +584,6 @@ The evaluator can pass this EA only if the evaluator confirms that:
 
 The evaluator shall report the summary of result of EA defined above, especially how the evaluator reaches the Pass/Fail judgement based on the Pass/Fail criteria.
 
-==== EA for FPT_BDP_EXT.2
-
-===== Objective of the EA
-
-The intention of this requirement is to prevent the logging, backing up or sending of plaintext biometric data to a service that transmits the information outside the security boundary of the SEE.
-
-For example, the TOE may transmit biometric data to the developer’s server for diagnostic purpose with the consent of the user. However, the TOE must encrypt the plaintext biometric data before sending it to the developer’s server for diagnostic purposes.
-
-In any case, the evaluator shall determine that the TOE does not transmit any plaintext biometric data outside the security boundary of the SEE.
-
-===== Dependency
-
-The evaluator shall perform the EAs for FPT_BDP_EXT.1 first to confirm the TSF processes any plaintext biometric data within the security boundary of the secure execution environment.
-
-===== Tool types required to perform the EA
-
-No tool is required for this EA.
-
-===== Required input from the developer or other entities
-
-Following input is required from the developer.
-
-[loweralpha]
-. TSS shall explain how the TOE meets FPT_BDP_EXT.2 at high level description
-. AGD guidance shall describe all functions that transmit biometric data
-
-===== Assessment Strategy
-
-====== Strategy for ASE_TSS and AGD_OPE/ADV_FSP
-
-The evaluator shall examine the TSS and AGD guidance to identify any functions that transmit biometric data to any entities outside the SEE and type of biometric data that is transmitted.
-
-If the TOE transmits biometric data, the evaluator shall examine the activities that happen on data transmission to confirm that;
-
-[loweralpha]
-. The TOE requires an explicit user consent and user authentication to enable the transmission
-
-. The TOE never transmits plaintext biometric data to outside the SEE. This means;
-+
-[arabic]
-.. The TOE encrypts plaintext biometric data to be transmitted using the cryptographic functions evaluated based on the base PP within the SEE
-.. If the TOE stores the encrypted biometric data outside the SEE for transmission, the TOE deletes such data after the transmission
-.. If the TOE displays the plaintext biometric data to the user to seek approval for transmission, such process is performed within the SEE
-
-. The TOE disables the transmission immediately after the TOE achieves its purpose
-
-===== Pass/Fail criteria
-
-The evaluator can pass this EA only if the evaluator confirms that:
-
-[loweralpha]
-. information necessary to perform this EA is described in the TSS and AGD guidance
-
-===== Requirements for reporting
-
-The evaluator shall report the summary of result of EA defined above, especially how the evaluator reaches the Pass/Fail judgement based on the Pass/Fail criteria.
-
-==== EA for FPT_BDP_EXT.3
-
-===== Objective of the EA
-
-Plaintext biometric data, especially templates, are highly sensitive personal data because biometric characteristics may be recovered from them. Plaintext biometric data shall be processed within the SEE as required by FPT_BDP_EXT.1. However, part of plaintext biometric data including templates may need to be stored in the computer for biometric verification. Protection of such stored biometric data is not covered by FPT_BDP_EXT.1.
-
-The evaluator shall confirm that the TOE encrypts plaintext biometric data within the SEE before storing it in any non-volatile memory that is accessible to entities outside the SEE. If the evaluator confirms that the TOE does not store plaintext biometric data outside the SEE (e.g. biometric capture sensor processes biometric data within the sensor and return only decision outcome to the TSF modules running inside the SEE) during performing the EA of FPT_BDP_EXT.1, this requirement is deemed satisfied.
-
-===== Dependency
-
-The evaluator shall perform the EAs for FPT_BDP_EXT.1 first to confirm the TSF processes any plaintext biometric data within the security boundary of the SEE.
-
-===== Tool types required to perform the EA
-
-Developer shall provide a test platform for the evaluator to conduct the test described in the Assessment Strategy.
-
-===== Required input from the developer or other entities
-
-Following input is required from the developer.
-
-[loweralpha]
-. TSS shall explain how the TOE meets FPT_BDP_EXT.3 at high level description
-. Supplementary information (file list/format and cryptographic algorithm) shall list storage locations and the format of files that contain biometric data, and the cryptographic algorithms used to encrypt those files
-
-===== Assessment Strategy
-
-====== Strategy for ASE_TSS
-
-The evaluator shall examine the TSS to understand the activities that happen on biometric enrolment and verification relating to encrypting and storing biometric data. The evaluator shall confirm that;
-
-[loweralpha]
-. The TSS lists the type of biometric data that the TOE stores in non-volatile memory outside the SEE
-. The TOE encrypts all plaintext biometric data listed in the TSS within the SEE before storing it in the non-volatile memory
-. The TOE uses cryptographic functions evaluated based on the base PP to encrypt the data
-
 ====== Strategy for ATE_IND
 
 The evaluator shall perform the following test to verify that the TOE encrypts plaintext biometric data if the TOE stores the data in non-volatile memory outside the SEE.
@@ -700,7 +612,7 @@ The evaluator shall report the summary of result of EA defined above, especially
 ==== EA for FPT_PBT_EXT.1
 
 ===== Objective of the EA
-Only an authenticated user can add one's own templates during biometric enrolment as defined in the FIA_MBE_EXT.1 and those templates are not stored outside the SEE without encryption as required by the FPT_BDP_EXT.3. However, the TOE may provide functions (e.g. revocation of templates) to access the templates. The evaluator shall confirm that only an authenticated user using a NBAF as specified by the ST author can access the templates through the TSFI provided by the TOE.
+Only an authenticated user can add one's own templates during biometric enrolment as defined in the FIA_MBE_EXT.1 and those templates are not stored as plaintext as required by the FPT_KST_EXT.1. However, the TOE may provide functions (e.g. revocation of templates) to access the templates. The evaluator shall confirm that only an authenticated user using a NBAF as specified by the ST author can access the templates through the TSFI provided by the TOE.
 
 ===== Dependency
 
@@ -742,6 +654,16 @@ The evaluator can pass this EA only if the evaluator confirms that:
 ===== Requirements for reporting
 
 The evaluator shall report the summary of result of EA defined above, especially how the evaluator reaches the Pass/Fail judgement based on the Pass/Fail criteria.
+
+== Evaluation Activities for PP_MD Requirements
+In addition to the EAs required by the base PP, the evaluator shall perform the following additional EAs to ensure that the base PP's security functionaltiy is maintained by the addition of the PP-Module.
+
+=== Modified SFRs from the base PP
+==== Protection of the TSF (FPT)
+===== Key Storage (FPT_KST)
+*FPT_KST_EXT.1*:: Refer to the EA for FPT_KST_EXT.1 in the PP_MD including biometric data as part of the plaintext key materials.
+
+*FPT_KST_EXT.2*:: Refer to the EA for FPT_KST_EXT.2 in the PP_MD including biometric data as part of the plaintext key materials.
 
 == Evaluation Activities for Selection-Based Requirements 
 


### PR DESCRIPTION
This closes #308 and closes #309.

This removes FPT_BDP_EXT.2/3 and replaces them with FPT_KST_EXT.1/2 from the MDF with modifications to add biometric data.

Secure Execution Environment -> Separate Execution Environment. This is from the MDF in sections FCS_CKM_EXT.1 & FCS_CKM_EXT.4, as a method of separation from the OS.

FPT_BDP_EXT.1 is changed to mirror FCS_CKM_EXT.1.2 in specifying some sort of hardware isolation (basically the SEE of some sort), and removed descriptions related to encryption for the EA.

A few other minor edits are included (things like version edits and some misspellings).