### PR TITLE
Quality metric update

### DIFF
--- a/Protection Profile/BiocPP.adoc
+++ b/Protection Profile/BiocPP.adoc
@@ -430,7 +430,7 @@ Target error rates defined in SFR shall be evaluated based on <<BIOSD>>. Normall
 
 ===== FIA_MBV_EXT.2 Quality of biometric samples for biometric verification [[FIA_MBV_EXT.2]]
 
-*FIA_MBV_EXT.2.1* The TSF shall only use biometric samples of sufficient quality for verification. As such, sample data shall have [*selection*: _no independent quality metric, [*assignment*: quality metric standard]_].
+*FIA_MBV_EXT.2.1* The TSF shall only use biometric samples of sufficient quality for verification. As such, sample data shall have [*selection*: _an internal quality metric_, [*assignment*: _quality metric standard_]], using a threshold of [*assignment*: _quality metric threshold_].
 
 *Application Note {counter:remark_count}*:: ST author may specify quality standards if the TOE follows such standard, or provide a description of the metrics used.
 

--- a/Protection Profile/BiocPP.adoc
+++ b/Protection Profile/BiocPP.adoc
@@ -432,7 +432,6 @@ Target error rates defined in SFR shall be evaluated based on <<BIOSD>>. Normall
 
 *FIA_MBV_EXT.2.1* The TSF shall only use biometric samples of sufficient quality for verification. As such, sample data shall have [*selection*: _an internal quality metric_, [*assignment*: _quality metric standard_]], using a threshold of [*assignment*: _quality metric threshold_].
 
-*Application Note {counter:remark_count}*:: ST author may specify quality standards if the TOE follows such standard, or provide a description of the metrics used.
 
 ==== Protection of the TSF (FPT)
 ===== FPT_BDP_EXT.1 Biometric data processing [[FPT_BDP_EXT.1]]

--- a/Protection Profile/BiocPP.adoc
+++ b/Protection Profile/BiocPP.adoc
@@ -432,9 +432,9 @@ Target error rates defined in SFR shall be evaluated based on <<BIOSD>>. Normall
 
 ===== FIA_MBV_EXT.2 Quality of biometric samples for biometric verification [[FIA_MBV_EXT.2]]
 
-*FIA_MBV_EXT.2.1* The TSF shall only use samples of sufficient quality to verify the user.
+*FIA_MBV_EXT.2.1* The TSF shall only use biometric samples of sufficient quality for verification. As such, sample data shall have [*selection*: _no independent quality metric, [*assignment*: quality metric standard]_].
 
-*Application Note {counter:remark_count}*:: ST author may refine “sufficient quality” to specify quality standards if the TOE follows such standard.
+*Application Note {counter:remark_count}*:: ST author may specify quality standards if the TOE follows such standard, or provide a description of the metrics used.
 
 ==== Protection of the TSF (FPT)
 ===== FPT_BDP_EXT.1 Biometric data processing [[FPT_BDP_EXT.1]]

--- a/Protection Profile/BiocPP.adoc
+++ b/Protection Profile/BiocPP.adoc
@@ -403,9 +403,9 @@ This section lists SFRs for the biometric enrolment and verification.
 
 ===== FIA_MBE_EXT.2 Quality of biometric templates for biometric enrolment [[FIA_MBE_EXT.2]]
 
-*FIA_MBE_EXT.2.1* The TSF shall create templates of sufficient quality.
+*FIA_MBE_EXT.2.1* The TSF shall only use biometric samples of sufficient quality for enrolment. As such, sample data shall have [*selection*: _no independent quality metric, [*assignment*: quality metric standard]_].
 
-*Application Note {counter:remark_count}*:: ST author may refine “sufficient quality” to specify quality standards if the TOE follows such standard.
+*Application Note {counter:remark_count}*:: ST author may specify quality standards if the TOE follows such standard, or provide a description of the metrics used.
 
 ===== FIA_MBV_EXT.1 Biometric verification [[FIA_MBV_EXT.1]]
 

--- a/Protection Profile/BiocPP.adoc
+++ b/Protection Profile/BiocPP.adoc
@@ -403,9 +403,7 @@ This section lists SFRs for the biometric enrolment and verification.
 
 ===== FIA_MBE_EXT.2 Quality of biometric templates for biometric enrolment [[FIA_MBE_EXT.2]]
 
-*FIA_MBE_EXT.2.1* The TSF shall only use biometric samples of sufficient quality for enrolment. As such, sample data shall have [*selection*: _no independent quality metric, [*assignment*: quality metric standard]_].
-
-*Application Note {counter:remark_count}*:: ST author may specify quality standards if the TOE follows such standard, or provide a description of the metrics used.
+*FIA_MBE_EXT.2.1* The TSF shall only use biometric samples of sufficient quality for enrolment. Sufficiency of sample data shall be determined by measuring sample with [*selection*: _an internal quality metric_, [*assignment*: _quality metric standard_]], using a threshold of [*assignment*: _quality metric threshold_].
 
 ===== FIA_MBV_EXT.1 Biometric verification [[FIA_MBV_EXT.1]]
 

--- a/Protection Profile/BiocPP.adoc
+++ b/Protection Profile/BiocPP.adoc
@@ -913,3 +913,8 @@ Hierarchical to: 	No other components
 Dependencies: 	No dependencies
 
 *FPT_PBT_EXT.1.1* The TSF shall protect the template [*selection*: _using a PIN as an additional factor, using a password as an additional factor_], [*assignment*: _other circumstances_]].
+
+== Biometrics Management Description (BMD)
+The documentation of the product's biometric functionality and performance should be detailed enough that, after reading, the evaluator will thoroughly understand the product's biometric functionality and performance. As some of this information may be considered confidential to the developer yet still necessary for understanding, this documentation is not required to be part of the TSS and can be submitted as a separate document marked as developer proprietary.
+
+Whether to use the BMD for any information is up to the developer. When used, a non-proprietary summary of the contents of the BMD must be provided in the TSS.

--- a/Supporting Documents/BS_SD.adoc
+++ b/Supporting Documents/BS_SD.adoc
@@ -326,8 +326,7 @@ Following input is required from the developer.
 
 [loweralpha]
 . TSS shall explain how the TOE meets FIA_MBE_EXT.2 at high level description
-** If an independent quality metric is claimed, the TSS must include information about the metric
-** If no independent quality metric is claimed, the TSS must include a desription of how quality is measured
+** If a non-standard (i.e., internal) quality metric is claimed, the TSS must include information about the metric
 . AGD guidance shall provide clear instructions for a user to enrol to the biometric system
 . Supplementary information ([#MBE assessment criteria for samples]#Assessment criteria for samples#) shall describe assessment criteria for creating samples
 

--- a/Supporting Documents/BS_SD.adoc
+++ b/Supporting Documents/BS_SD.adoc
@@ -424,6 +424,8 @@ Following input is required from the developer.
 
 [loweralpha]
 . TSS shall explain how the TOE meets FIA_MBV_EXT.1 at high level description
+** If an independent quality metric is claimed, the TSS must include information about the metric
+** If no independent quality metric is claimed, the TSS must include a desription of how quality is measured
 . AGD guidance shall provide clear instructions for a user to verify one's biometric to unlock the computer
 . Supplementary information (developer’s [#performance report]#performance report#) shall describe the developer’s performance test protocol and result of testing
 

--- a/Supporting Documents/BS_SD.adoc
+++ b/Supporting Documents/BS_SD.adoc
@@ -423,8 +423,7 @@ Following input is required from the developer.
 
 [loweralpha]
 . TSS shall explain how the TOE meets FIA_MBV_EXT.1 at high level description
-** If an independent quality metric is claimed, the TSS must include information about the metric
-** If no independent quality metric is claimed, the TSS must include a desription of how quality is measured
+** If a non-standard (i.e., internal) quality metric is claimed, the TSS must include information about the metric
 . AGD guidance shall provide clear instructions for a user to verify one's biometric to unlock the computer
 . Supplementary information (developer’s [#performance report]#performance report#) shall describe the developer’s performance test protocol and result of testing
 

--- a/Supporting Documents/BS_SD.adoc
+++ b/Supporting Documents/BS_SD.adoc
@@ -326,6 +326,8 @@ Following input is required from the developer.
 
 [loweralpha]
 . TSS shall explain how the TOE meets FIA_MBE_EXT.2 at high level description
+** If an independent quality metric is claimed, the TSS must include information about the metric
+** If no independent quality metric is claimed, the TSS must include a desription of how quality is measured
 . AGD guidance shall provide clear instructions for a user to enrol to the biometric system
 . Supplementary information ([#MBE assessment criteria for samples]#Assessment criteria for samples#) shall describe assessment criteria for creating samples
 


### PR DESCRIPTION
This is to close #314

This is a modification from the MDF v3.2 requirement to make it explicit that a vendor can choose their own metric (with a description to be specified) or an independent one (such as NFIQ, though I haven't added a reference for it, and I'm not sure if we should in the app note or not).

I added some bullets in the SD to note this as well.