### PR TITLE
FIA_MBV_EXT.1.1 remove assignment

### DIFF
--- a/Protection Profile/BiocPP.adoc
+++ b/Protection Profile/BiocPP.adoc
@@ -796,7 +796,7 @@ Hierarchical to: No other components
 
 Dependencies: FIA_MBE_EXT.1 Biometric enrolment
 
-*FIA_MBV_EXT.1.1* The TSF shall provide a biometric verification mechanism using [*selection:* _fingerprint, eye, face, voice, vein_, [*assignment:* _other modality_]].
+*FIA_MBV_EXT.1.1* The TSF shall provide a biometric verification mechanism using [*selection:* _eye, face, fingerprint, vein_].
 
 *FIA_MBV_EXT.1.2* The TSF shall provide a biometric verification mechanism with the [*selection:* _FMR, FAR_] not exceeding [*assignment:* _defined value_] and [*selection:* _FNMR, FRR_] not exceeding [*assignment:* _defined value_].
 

--- a/Protection Profile/BiocPP.adoc
+++ b/Protection Profile/BiocPP.adoc
@@ -409,7 +409,7 @@ This section lists SFRs for the biometric enrolment and verification.
 
 ===== FIA_MBV_EXT.1 Biometric verification [[FIA_MBV_EXT.1]]
 
-*FIA_MBV_EXT.1.1*:: The TSF shall provide a biometric verification mechanism using [*selection*: _fingerprint, eye, face, voice, vein_, [*assignment*: _other modality_]].
+*FIA_MBV_EXT.1.1*:: The TSF shall provide a biometric verification mechanism using [*selection*: _eye, face, fingerprint, vein_].
 
 *FIA_MBV_EXT.1.2*:: The TSF shall provide a biometric verification mechanism with the [*selection*: _FMR, FAR_] not exceeding [*assignment*: _defined value_] and [*selection*: _FNMR, FRR_] not exceeding [*assignment*: _defined value_].
 


### PR DESCRIPTION
This is to close #305.

This removes the assignment that we had allowed originally. The original thinking was that to use the assignment the vendor would have had to provide PAD and everything else, it wouldn't just be allowed, but NIAP prefers more explicit control (which is fine).

What I would expect as the proper course for this would be the vendor asks to add a new modality, and once everything has been submitted and approved, a TD would be issued to add the new modality to the list. This ensures that only approved modalities are allowed, and they must be approved before.

I alphabetized the list so there isn't any particular preference among the modalities.

I removed Voice because we don't have a toolbox for it at this time.

The other issue about the app note is already resolved by #315.