### PR TITLE
Changes to have less MDF changes

### DIFF
--- a/Protection Profile/BiocPP.adoc
+++ b/Protection Profile/BiocPP.adoc
@@ -386,18 +386,18 @@ TODO: Need to add additional EAs for modified and additional SFR to <<BIOSD>>
 The SFRs listed in this section are defined in the <<PP_MD_V3.3>> and relevant to the secure operation of the biometric enrolment and verification. It is necessary for the ST author to complete selections and/or assignments for these SFRs in a specific manner in order to ensure that the functionality provided by the mobile device is consistent with the functionality required by the biometric enrolment and verification in order for it to conform to this PP-Module.
 
 ===== FCS_CKM_EXT.4 Key Destruction [[FCS_CKM_EXT.4]]
+This SFR is identical to what is defined in the <<PP_MD_V3.3>>. The change is to the application note.
 
-*Application Note {counter:remark_count}*:: This SFR is functionally identical to what is defined in the <<PP_MD_V3.3>>. However, the following note should be added to the Application note of FCS_CKM_EXT.4. 
-+
-*If biometric data processing occurs in a separate execution environment on the same Application Processor as the main computer operating system, the biometric data must be cleared from RAM immediately after use, and at least, must be wiped when the device is locked.*
+*Application Note:* For the purposes of this requirement, plaintext keying material refers to authentication data, passwords, secret/private symmetric keys, private asymmetric keys, data used to derive keys, values derived from passwords, etc. *Biometric data used for enrolment or verification are considered critical security parameters that must be destroyed when no longer needed.*
+
+*Application Note {counter:remark_count}*:: The the Application Note following FCS_CKM_EXT.4.2 is modified to add the text to include biometric data as a critical security parameter to ensure it is handled properly by the TSF.
 
 ===== FPT_AEX_EXT.4 Domain Isolation [[FPT_AEX_EXT.4]]
+This SFR is identical to what is defined in the <<PP_MD_V3.3>>. The change is to the application note.
 
-*FPT_AEX_EXT.4.1*:: The TSF shall protect itself from modification by untrusted subjects.
-*FPT_AEX_EXT.4.2*:: The TSF shall enforce isolation of address space between applications. 
-*FPT_AEX_EXT.4.3*:: *The TSF shall enforce isolation between the operating system and the separate execution environment.* 
+*Application Note:* In addition to the TSF software (e.g., kernel image, device drivers, trusted applications) that resides in storage, the execution context (e.g., address space, processor registers, per-process environment variables) of the software operating in a privileged mode of the processor (e.g., kernel, *other processor modes*) *or on separate processors*, as well as the context of the trusted applications is to be protected. In addition to the software, any configuration information that controls or influences the behavior of the TSF is also to be protected from modification by untrusted subjects.
 
-*Application Note {counter:remark_count}*:: This SFR is functionally identical to what is defined in the <<PP_MD_V3.3>> with the addition of FPT_AEX_EXT.4.3 that requires the mobile device to provide the separate execution environment isolated from the operating system. FPT_BDP_EXT.1 requires the biometric system to process plaintext biometric data in this separate execution environment.
+*Application Note {counter:remark_count}*:: This application note explicitly adds more support for additional processor modes (e.g. the Secure/Normal World modes defined in a Trusted Execution Environment) or separate processors (e.g. a secure element) that may be present and used for the processing of biometric data. Biometric components should be considered as TSF software being protected by these mechanisms, defined as the separate execution environment.
 
 ===== FPT_KST_EXT.1 Key Storage [[FPT_KST_EXT.1]]
 

--- a/Protection Profile/BiocPP.adoc
+++ b/Protection Profile/BiocPP.adoc
@@ -390,7 +390,7 @@ This SFR is identical to what is defined in the <<PP_MD_V3.3>>. The change is to
 
 *Application Note:* For the purposes of this requirement, plaintext keying material refers to authentication data, passwords, secret/private symmetric keys, private asymmetric keys, data used to derive keys, values derived from passwords, etc. *Biometric data used for enrolment or verification are considered critical security parameters that must be destroyed when no longer needed.*
 
-*Application Note {counter:remark_count}*:: The the Application Note following FCS_CKM_EXT.4.2 is modified to add the text to include biometric data as a critical security parameter to ensure it is handled properly by the TSF.
+*Application Note {counter:remark_count}*:: The Application Note following FCS_CKM_EXT.4.2 is modified to add the text to include biometric data as a critical security parameter to ensure it is handled properly by the TSF.
 
 ===== FPT_AEX_EXT.4 Domain Isolation [[FPT_AEX_EXT.4]]
 This SFR is identical to what is defined in the <<PP_MD_V3.3>>. The change is to the application note.

--- a/Supporting Documents/BS_SD.adoc
+++ b/Supporting Documents/BS_SD.adoc
@@ -662,11 +662,19 @@ The evaluator shall report the summary of result of EA defined above, especially
 In addition to the EAs required by the Base-PP, the evaluator shall perform the following additional EAs to ensure that the Base-PP's security functionaltiy is maintained by the addition of the PP-Module.
 
 === Modified SFRs from the Base-PP
-==== Protection of the TSF (FPT)
-===== Key Storage (FPT_KST)
-*FPT_KST_EXT.1*:: Refer to the EA for FPT_KST_EXT.1 in the <<PP_MD_V3.3>> including biometric data as part of the plaintext key materials.
+==== Cryptographic Support (FCS)
+===== FCS_CKM_EXT.4 Key Destruction
+Refer to the EA for FCS_CKM_EXT.4 in the <<PP_MD_V3.3>> including biometric data as critical security parameters for the EA.
 
-*FPT_KST_EXT.2*:: Refer to the EA for FPT_KST_EXT.2 in the <<PP_MD_V3.3>> including biometric data as part of the plaintext key materials.
+==== Protection of the TSF (FPT)
+===== FPT_AEX_EXT.4 Domain Isolation 
+Refer to the EA for FPT_AEX_EXT.4 in the <<PP_MD_V3.3>> including the protection of biometric data in the isolation description.
+
+===== Key Storage (FPT_KST_EXT.1)
+Refer to the EA for FPT_KST_EXT.1 in the <<PP_MD_V3.3>> including biometric data as part of the plaintext key materials.
+
+===== NO Key Transmission (FPT_KST_EXT.2)
+Refer to the EA for FPT_KST_EXT.2 in the <<PP_MD_V3.3>> including biometric data as part of the plaintext key materials.
 
 == Evaluation Activities for Selection-Based Requirements 
 


### PR DESCRIPTION
This tries to make the application note edits more explicit by copying in the paragraph from the MDF and adding edits to it here (I don't know if that is the right way or if NIAP would prefer something else).

I have removed the new FPT_AEX_EXT4.3 requirement by adjusting the app note to have more explicit notes about separate processor modes or even processors so it is clear these can be part of the description. We can suggest an SEE concept to NIAP for the revision where we are linked, but I think we should minimize drastic changes from our side for that. So I have tried to define it within. I think this should work, but maybe requires some more definition as to the expected description about what we would want to see (probably under the SD which I have added these into, but just by pointing them to the original EA).