### PR TITLE
IAPAR update

### DIFF
--- a/Protection Profile/BiocPP.adoc
+++ b/Protection Profile/BiocPP.adoc
@@ -88,8 +88,6 @@ False Reject Rate (FRR)::
 	Digital representation of the information extracted from a sample (by the signal processing subsystem) that will be used to construct or compare against enrolment templates.
 Imposter Attack Presentation Accept Rate (IAPAR)::
     In a full-system evaluation of a verification system, proportion of impostor presentation attacks using the same artefact type that result in a accept.
-Imposter Attack Presentation Accept Rate for enrolment (IAPARE)::
-    In a full-system evaluation of a enrolment system, proportion of impostor presentation attacks using the same artefact type that result in a successful enrolment.
 Locked State::
 	Powered on Computer, with most functionalities unavailable for use. User authentication is required to access full functionality.
 (Biometric) Modality::
@@ -662,7 +660,7 @@ ST authors are free to choose none, some or all SFRs defined in this Section. Ju
 
 ==== FIA_MBE_EXT.3 Presentation attack detection for biometric enrolment [[FIA_MBE_EXT.3]]
 
-*FIA_MBE_EXT.3.1*:: The TSF shall provide a biometric enrolment mechanism with the IAPARE not exceeding [*assignment*: _value equal to or less than 15% (15:100)_] to prevent use of artificial presentation attack instruments from being successfully enroled.
+*FIA_MBE_EXT.3.1*:: The TSF shall prevent use of artificial presentation attack instruments from being successfully enroled.
 
 ==== FIA_MBV_EXT.3 Presentation attack detection for biometric verification [[FIA_MBV_EXT.3]]
 
@@ -760,7 +758,7 @@ Hierarchical to: No other components
 
 Dependencies: FIA_MBE_EXT.1 Biometric enrolment
 
-*FIA_MBE_EXT.3.1*:: The TSF shall provide a biometric enrolment mechanism with the IAPARE not exceeding [*assignment*: _value equal to or less than 15% (15:100)_] to prevent use of artificial presentation attack instruments from being successfully enroled.
+*FIA_MBE_EXT.3.1*:: The TSF shall prevent use of artificial presentation attack instruments from being successfully enroled.
 
 ==== Biometric verification (FIA_MBV_EXT)
 

--- a/Protection Profile/BiocPP.adoc
+++ b/Protection Profile/BiocPP.adoc
@@ -88,6 +88,8 @@ False Reject Rate (FRR)::
 	Digital representation of the information extracted from a sample (by the signal processing subsystem) that will be used to construct or compare against enrolment templates.
 Imposter Attack Presentation Accept Rate (IAPAR)::
     In a full-system evaluation of a verification system, proportion of impostor presentation attacks using the same artefact type that result in a accept.
+Imposter Attack Presentation Accept Rate for enrolment (IAPARE)::
+    In a full-system evaluation of a enrolment system, proportion of impostor presentation attacks using the same artefact type that result in a successful enrolment.
 Locked State::
 	Powered on Computer, with most functionalities unavailable for use. User authentication is required to access full functionality.
 (Biometric) Modality::
@@ -660,7 +662,7 @@ ST authors are free to choose none, some or all SFRs defined in this Section. Ju
 
 ==== FIA_MBE_EXT.3 Presentation attack detection for biometric enrolment [[FIA_MBE_EXT.3]]
 
-*FIA_MBE_EXT.3.1*:: The TSF shall provide a biometric enrolment mechanism with the IAPAR not exceeding [*assignment*: _value equal to or less than 15% (15:100)_] to prevent use of artificial presentation attack instruments from being successfully enroled.
+*FIA_MBE_EXT.3.1*:: The TSF shall provide a biometric enrolment mechanism with the IAPARE not exceeding [*assignment*: _value equal to or less than 15% (15:100)_] to prevent use of artificial presentation attack instruments from being successfully enroled.
 
 ==== FIA_MBV_EXT.3 Presentation attack detection for biometric verification [[FIA_MBV_EXT.3]]
 
@@ -758,7 +760,7 @@ Hierarchical to: No other components
 
 Dependencies: FIA_MBE_EXT.1 Biometric enrolment
 
-*FIA_MBE_EXT.3.1*:: The TSF shall provide a biometric enrolment mechanism with the IAPAR not exceeding [*assignment*: _value equal to or less than 15% (15:100)_] to prevent use of artificial presentation attack instruments from being successfully enroled.
+*FIA_MBE_EXT.3.1*:: The TSF shall provide a biometric enrolment mechanism with the IAPARE not exceeding [*assignment*: _value equal to or less than 15% (15:100)_] to prevent use of artificial presentation attack instruments from being successfully enroled.
 
 ==== Biometric verification (FIA_MBV_EXT)
 

--- a/Protection Profile/BiocPP.adoc
+++ b/Protection Profile/BiocPP.adoc
@@ -86,6 +86,8 @@ False Reject Rate (FRR)::
 	Proportion of verification transactions with truthful biometric claims of identity that are incorrectly denied.
 (Biometric) Features::
 	Digital representation of the information extracted from a sample (by the signal processing subsystem) that will be used to construct or compare against enrolment templates.
+Imposter Attack Presentation Accept Rate (IAPAR)::
+    In a full-system evaluation of a verification system, proportion of impostor presentation attacks using the same artefact type that result in a accept.
 Locked State::
 	Powered on Computer, with most functionalities unavailable for use. User authentication is required to access full functionality.
 (Biometric) Modality::
@@ -658,11 +660,11 @@ ST authors are free to choose none, some or all SFRs defined in this Section. Ju
 
 ==== FIA_MBE_EXT.3 Presentation attack detection for biometric enrolment [[FIA_MBE_EXT.3]]
 
-*FIA_MBE_EXT.3.1*:: The TSF shall prevent use of artificial presentation attack instruments from being successfully enroled.
+*FIA_MBE_EXT.3.1*:: The TSF shall provide a biometric enrolment mechanism with the IAPAR not exceeding [*assignment*: _value equal to or less than 15% (15:100)_] to prevent use of artificial presentation attack instruments from being successfully enroled.
 
 ==== FIA_MBV_EXT.3 Presentation attack detection for biometric verification [[FIA_MBV_EXT.3]]
 
-*FIA_MBV_EXT.3.1*:: The TSF shall prevent use of artificial presentation attack instruments from being successfully verified.
+*FIA_MBV_EXT.3.1*:: The TSF shall provide a biometric verification mechanism with the IAPAR not exceeding [*assignment*: _value equal to or less than 15% (15:100)_] to prevent use of artificial presentation attack instruments from being successfully verified.
 
 *Application Note {counter:remark_count}*:: Artefacts that the TOE prevent and relevant criteria for its security relevant error rates for each type of artefact is defined in <<BIOSD>>.
 
@@ -756,7 +758,7 @@ Hierarchical to: No other components
 
 Dependencies: FIA_MBE_EXT.1 Biometric enrolment
 
-*FIA_MBE_EXT.3.1*:: The TSF shall prevent use of artificial presentation attack instruments from being successfully enroled.
+*FIA_MBE_EXT.3.1*:: The TSF shall provide a biometric enrolment mechanism with the IAPAR not exceeding [*assignment*: _value equal to or less than 15% (15:100)_] to prevent use of artificial presentation attack instruments from being successfully enroled.
 
 ==== Biometric verification (FIA_MBV_EXT)
 
@@ -843,7 +845,7 @@ FIA_MBE_EXT.1 Biometric enrolment
 
 FIA_MBV_EXT.1 Biometric verification
 
-*FIA_MBV_EXT.3.1*:: The TSF shall prevent use of artificial presentation attack instruments from being successfully verified.
+*FIA_MBV_EXT.3.1*:: The TSF shall provide a biometric verification mechanism with the IAPAR not exceeding [*assignment*: _value equal to or less than 15% (15:100)_] to prevent use of artificial presentation attack instruments from being successfully verified.
 
 
 === Protection of the TSF (FPT)

--- a/Supporting Documents/BS_SD.adoc
+++ b/Supporting Documents/BS_SD.adoc
@@ -161,9 +161,6 @@ For definitions of standard CC terminology see <<CC1>>. For definitions of biome
 |*IAPAR*
 |Imposter Attack Presentation Accept Rate
 
-|*IAPARE*
-|Imposter Attack Presentation Accept Rate for enrolment
-
 |*iTC* 
 |International Technical Community
 
@@ -875,9 +872,9 @@ As described in previous section, the <<Toolbox>> defines test items to create a
 
 During the independent testing, the evaluator may find artefacts that are incorrectly matched to the enroled target user however, the evaluator may not be able to reliably reproduce a successful presentation attack.
 
-The <<Toolbox>> defines the Pass/Fail criteria, maximum IAPAR/IAPARE for artefacts. The evaluator shall follow the <<Toolbox>> criteria for the number of artefact presentations and confirm that the TOE’s match rate is below the specified criteria during the independent testing. The evaluator shall assign a fail verdict to those TOE that do not satisfy the criteria.
+The <<Toolbox>> defines the Pass/Fail criteria, maximum IAPAR for artefacts. The evaluator shall follow the <<Toolbox>> criteria for the number of artefact presentations and confirm that the TOE’s match rate is below the specified criteria during the independent testing. The evaluator shall assign a fail verdict to those TOE that do not satisfy the criteria.
 
-The artefacts that pass the criteria but show the higher IAPAR/IAPARE will be tested again during the AVA_VAN.1 evaluation.
+The artefacts that pass the criteria but show the higher IAPAR will be tested again during the AVA_VAN.1 evaluation.
 
 The <<Toolbox>> does not necessarily cover all biometric modalities, but only existing modalities with approved <<Toolbox>> tests can be used. If the developer wants to evaluate modalities not currently included in the <<Toolbox>>, the developer and evaluator shall contact the BIO-iTC to work together to add the new modality and extend the <<Toolbox>>. Upon the BIO-iTC approval of this extension, the evaluator can proceed with PAD evaluation for the new modality.
 
@@ -948,7 +945,7 @@ The evaluator shall perform EAs in <<No new artefacts found test plan>> if there
 
 ====== No new artefacts found test plan
 
-The evaluator shall select those artefacts that show higher IAPAR/IAPARE at the independent testing. The evaluator shall test them extensively during the penetration testing.
+The evaluator shall select those artefacts that show higher IAPAR at the independent testing. The evaluator shall test them extensively during the penetration testing.
 
 If there are no such artefacts, the evaluator should select “higher quality” artefacts. “Higher quality” means that artefacts are closer in resemblance to the biometric characteristics of the target user (e.g. higher resolution photo for face artefact).
 

--- a/Supporting Documents/BS_SD.adoc
+++ b/Supporting Documents/BS_SD.adoc
@@ -161,6 +161,9 @@ For definitions of standard CC terminology see <<CC1>>. For definitions of biome
 |*IAPAR*
 |Imposter Attack Presentation Accept Rate
 
+|*IAPARE*
+|Imposter Attack Presentation Accept Rate for enrolment
+
 |*iTC* 
 |International Technical Community
 
@@ -872,9 +875,9 @@ As described in previous section, the <<Toolbox>> defines test items to create a
 
 During the independent testing, the evaluator may find artefacts that are incorrectly matched to the enroled target user however, the evaluator may not be able to reliably reproduce a successful presentation attack.
 
-The <<Toolbox>> defines the Pass/Fail criteria, maximum IAPAR for artefacts. The evaluator shall follow the <<Toolbox>> criteria for the number of artefact presentations and confirm that the TOE’s match rate is below the specified criteria during the independent testing. The evaluator shall assign a fail verdict to those TOE that do not satisfy the criteria.
+The <<Toolbox>> defines the Pass/Fail criteria, maximum IAPAR/IAPARE for artefacts. The evaluator shall follow the <<Toolbox>> criteria for the number of artefact presentations and confirm that the TOE’s match rate is below the specified criteria during the independent testing. The evaluator shall assign a fail verdict to those TOE that do not satisfy the criteria.
 
-The artefacts that pass the criteria but show the higher IAPAR will be tested again during the AVA_VAN.1 evaluation.
+The artefacts that pass the criteria but show the higher IAPAR/IAPARE will be tested again during the AVA_VAN.1 evaluation.
 
 The <<Toolbox>> does not necessarily cover all biometric modalities, but only existing modalities with approved <<Toolbox>> tests can be used. If the developer wants to evaluate modalities not currently included in the <<Toolbox>>, the developer and evaluator shall contact the BIO-iTC to work together to add the new modality and extend the <<Toolbox>>. Upon the BIO-iTC approval of this extension, the evaluator can proceed with PAD evaluation for the new modality.
 
@@ -945,7 +948,7 @@ The evaluator shall perform EAs in <<No new artefacts found test plan>> if there
 
 ====== No new artefacts found test plan
 
-The evaluator shall select those artefacts that show higher IAPAR at the independent testing. The evaluator shall test them extensively during the penetration testing.
+The evaluator shall select those artefacts that show higher IAPAR/IAPARE at the independent testing. The evaluator shall test them extensively during the penetration testing.
 
 If there are no such artefacts, the evaluator should select “higher quality” artefacts. “Higher quality” means that artefacts are closer in resemblance to the biometric characteristics of the target user (e.g. higher resolution photo for face artefact).
 

--- a/Supporting Documents/BS_SD.adoc
+++ b/Supporting Documents/BS_SD.adoc
@@ -158,6 +158,9 @@ For definitions of standard CC terminology see <<CC1>>. For definitions of biome
 |*FRR*
 |False Reject Rate
 
+|*IAPAR*
+|Imposter Attack Presentation Accept Rate
+
 |*iTC* 
 |International Technical Community
 
@@ -869,9 +872,9 @@ As described in previous section, the <<Toolbox>> defines test items to create a
 
 During the independent testing, the evaluator may find artefacts that are incorrectly matched to the enroled target user however, the evaluator may not be able to reliably reproduce a successful presentation attack.
 
-The <<Toolbox>> defines the Pass/Fail criteria, maximum imposter attack presentation match rate for artefacts. The evaluator shall follow the <<Toolbox>> criteria for the number of artefact presentations and confirm that the TOE’s match rate is below the specified criteria during the independent testing. The evaluator shall assign a fail verdict to those TOE that do not satisfy the criteria.
+The <<Toolbox>> defines the Pass/Fail criteria, maximum IAPAR for artefacts. The evaluator shall follow the <<Toolbox>> criteria for the number of artefact presentations and confirm that the TOE’s match rate is below the specified criteria during the independent testing. The evaluator shall assign a fail verdict to those TOE that do not satisfy the criteria.
 
-The artefacts that pass the criteria but show the higher imposter attack presentation match rate will be tested again during the AVA_VAN.1 evaluation.
+The artefacts that pass the criteria but show the higher IAPAR will be tested again during the AVA_VAN.1 evaluation.
 
 The <<Toolbox>> does not necessarily cover all biometric modalities, but only existing modalities with approved <<Toolbox>> tests can be used. If the developer wants to evaluate modalities not currently included in the <<Toolbox>>, the developer and evaluator shall contact the BIO-iTC to work together to add the new modality and extend the <<Toolbox>>. Upon the BIO-iTC approval of this extension, the evaluator can proceed with PAD evaluation for the new modality.
 
@@ -942,7 +945,7 @@ The evaluator shall perform EAs in <<No new artefacts found test plan>> if there
 
 ====== No new artefacts found test plan
 
-The evaluator shall select those artefacts that show higher imposter attack presentation match rate at the independent testing. The evaluator shall test them extensively during the penetration testing.
+The evaluator shall select those artefacts that show higher IAPAR at the independent testing. The evaluator shall test them extensively during the penetration testing.
 
 If there are no such artefacts, the evaluator should select “higher quality” artefacts. “Higher quality” means that artefacts are closer in resemblance to the biometric characteristics of the target user (e.g. higher resolution photo for face artefact).
 
@@ -1670,6 +1673,7 @@ Example of warnings is that the AGD guidance may warn that the biometric verific
 - [#ISO19795-2]#[ISO/IEC 19795-2]# Biometric performance testing and reporting - Part 2: Testing methodologies for technology and scenario evaluation, First edition.    
 - [#ISO19795-3]#[ISO/IEC 19795-3]# Biometric performance testing and reporting - Part 3: Modality-specific testing, First edition.
 - [#ISO19989-1]#[ISO/IEC 19989-1]# Criteria and methodology for security evaluation of biometric systems – Part 1: Framework, Under development.  
-- [#ISO30107-3]#[ISO/IEC 30107-3]# Biometric presentation attack detection — Part 3: Testing and reporting, First edition.        
+- [#ISO30107-3]#[ISO/IEC 30107-3]# Biometric presentation attack detection - Part 3: Testing and reporting, First edition.
+- [#ISO30107-4]#[ISO/IEC 30107-4]# Biometric presentation attach detection - Part 4: Profile for testing of mobile devices, First edition.
 - [#BEAT]#[BEAT]# Biometrics Evaluation and Testing, https://www.beat-eu.org.
 - [#Biometric quality]#[Biometric quality]# Biometric quality: a review of fingerprint, iris, and face - July 2, 2014, https://link.springer.com/article/10.1186/1687-5281-2014-34.


### PR DESCRIPTION
This is to close #343

One concern I have here is that I updated FIA_MBE_EXT.3.1 to match, but technically IAPAR is for verification, so I'm not sure we can use that for enrolment. I don't know what to do if we don't, since then the enrolment requirement is vague, but I also don't know if an IAPAR for verification is in any way equivalent for enrolment.

I didn't make any further changes in terms of tables or such that would explain the calculations or anything differently (or more explicitly), so we may end up needing to do something along those lines, but I'm not sure.