### PR TITLE
date and allowed list

### DIFF
--- a/PP-Configurations/PP_MD/PP_Config.adoc
+++ b/PP-Configurations/PP_MD/PP_Config.adoc
@@ -3,7 +3,7 @@
 :toc:
 :table-caption: Table
 :revnumber: 1.1
-:revdate: July 19, 2022
+:revdate: September 12, 2022
 :xrefstyle: full
 :doctype: book
 
@@ -22,20 +22,20 @@ The purpose of a PP-Configuration is to define a Target of Evaluation (TOE) that
 
 This PP-Configuration is identified as follows:
 
-* PP-Configuration for Protection Profile for Mobile Device Fundamentals and collaborative PP-Module for Biometric enrolment and verification - for unlocking the device - version 1.1, July 19, 2022 - <<CFG-MDF-BIO>>
+* PP-Configuration for Protection Profile for Mobile Device Fundamentals and collaborative PP-Module for Biometric enrolment and verification - for unlocking the device - Version 1.1, September 12, 2022 - <<CFG-MDF-BIO>>
 
 == PP-Configuration Components Statement
 
 This PP-Configuration includes the following components:
 
-* Base-PP: Protection Profile for Mobile Device Fundamentals, Version:3.3. <<PP_MDF>>
-* PP-Module: collaborative PP-Module for Biometric enrolment and verification - for unlocking the device - <<BIOPP-Module>>
+* Base-PP: Protection Profile for Mobile Device Fundamentals, September 12, 2022, Version 3.3. <<PP_MDF>>
+* PP-Module: collaborative PP-Module for Biometric enrolment and verification - for unlocking the device - BIOPP-Module, September 12, 2022, Version 1.1 <<MOD_BIO_V1.0>>
 
 == Conformance claim and conformance statement
 
 === Common Criteria Conformance claim
 
-This PP-Configuration, <<PP_MDF>> and <<BIOPP-Module>> are conformant to Common Criteria Version 3.1, Revision 5.
+This PP-Configuration, <<PP_MDF>> and <<MOD_BIO_V1.0>> are conformant to Common Criteria Version 3.1, Revision 5.
 
 === The conformance type
 
@@ -90,7 +90,7 @@ In order to evaluate a TOE that claims conformance to the Presentation Attack De
 
 **Common Criteria**footnote:[For details see http://www.commoncriteriaportal.org/]
 
-[cols="1,3",]
+[cols=".^1,3",]
 |===
 |[#CC1]#[CC1]# |Common Criteria for Information Technology Security Evaluation, +
 Part 1: Introduction and General Model, +
@@ -111,19 +111,19 @@ Version 0.5, May 2017.
 
 *Protection Profiles*
 
-[cols="1,3",]
+[cols=".^1,3",]
 |===
 |[#PP_MDF]#[PP_MDF]# 
-|Protection Profile for Mobile Device Fundamentals, Version: 3.3
+|Protection Profile for Mobile Device Fundamentals, September 12, 2022, Version 3.3
 
-|[#BIOPP-Module]#[BIOPP-Module]# 
-|collaborative PP-Module for Biometric enrolment and verification - for unlocking the device -, July 19, 2022, Version 1.1 - [BIOPP-Module]
+|[#MOD_BIO_V1.0]#[MOD_BIO_V1.0]# 
+|collaborative PP-Module for Biometric enrolment and verification - for unlocking the device -, September 12, 2022, Version 1.1 - [BIOPP-Module]
 
 |[#BIOSD]#[BIOSD]#
-|Supporting Document Mandatory Technical Document: Evaluation Activities for collaborative PP-Module for Biometric enrolment and verification - for unlocking the device -, July 19, 2022, Version 1.1 - [BIOSD]
+|Supporting Document Mandatory Technical Document: Evaluation Activities for collaborative PP-Module for Biometric enrolment and verification - for unlocking the device -, September 12, 2022, Version 1.1 - [BIOSD]
 
 |[#Toolbox]#[Toolbox]# 
-|Toolbox Overview, July 19, 2022, Version 1.1
+|Toolbox Overview, September 12, 2022, Version 1.1
 
 |===
 
@@ -161,7 +161,7 @@ Version 0.5, May 2017.
 |Public Release (requires PP_MDF_V3.3 release to move to v1.0)
 
 |1.1
-|July 19, 2022
+|September 12, 2022
 |Version 1.1
 
 |===

--- a/Protection Profile/BiocPP.adoc
+++ b/Protection Profile/BiocPP.adoc
@@ -6,7 +6,7 @@
 :sectnumlevels: 5
 :imagesdir: images
 :revnumber: 1.1
-:revdate: July 19, 2022
+:revdate: September 12, 2022
 :xrefstyle: full
 :doctype: book
 
@@ -41,9 +41,9 @@ Although the PP-Module and Supporting Document <<BIOSD>> may contain minor edito
 - [#CEM]#[CEM]#	Common Methodology for Information Technology Security Evaluation, Evaluation Methodology, CCMB-2017-04-004, Version 3.1 Revision 5, April 2017.
 - [#addenda]#[addenda]#	CC and CEM addenda, Exact Conformance, Selection-Based SFRs, Optional SFRs, Version 0.5, May 2017.
 - [#PP_OS]#[PP_OS]# Protection Profile for General Purpose Operating Systems.
-- [#PP_MDF]#[PP_MDF]# Protection Profile for Mobile Device Fundamentals, Version: 3.3.
-- [#CFG-MDF-BIO]#[CFG-MDF-BIO]# PP-Configuration for Protection Profile for Mobile Device Fundamentals and collaborative PP-Module for Biometric enrolment and verification - for unlocking the device -, July 19, 2022, Version 1.1 [CFG-MDF-BIO].
-- [#BIOSD]#[BIOSD]# Supporting Document Mandatory Technical Document: Evaluation Activities for collaborative PP-Module for Biometric enrolment and verification - for unlocking the device -, July 19, 2022, Version 1.1 - [BIOSD].
+- [#PP_MDF]#[PP_MDF]# Protection Profile for Mobile Device Fundamentals, September 12, 2022, Version 3.3.
+- [#CFG-MDF-BIO]#[CFG-MDF-BIO]# PP-Configuration for Protection Profile for Mobile Device Fundamentals and collaborative PP-Module for Biometric enrolment and verification - for unlocking the device -, September 12, 2022, Version 1.1 [CFG-MDF-BIO].
+- [#BIOSD]#[BIOSD]# Supporting Document Mandatory Technical Document: Evaluation Activities for collaborative PP-Module for Biometric enrolment and verification - for unlocking the device -, September 12, 2022, Version 1.1 - [BIOSD].
 - [#ISO/IEC 19795-1]#[ISO/IEC 19795-1]# Biometric performance testing and reporting — Part 1: Principles and framework, First edition.
 - [#ISO/IEC 29156]#[ISO/IEC 29156]# Information technology - Guidance for specifying performance requirements to meet security and usability needs in applications using biometrics, 2015.
 - [#ISO/IEC 30107-1]#[ISO/IEC 30107-1]# Biometric presentation attack detection - Part 1: Framework, First edition.
@@ -165,7 +165,7 @@ Zero-effort Impostor Attempt::
 |Public Release
 
 |1.1
-|July 19, 2022
+|September 12, 2022
 |Incorporated TDs and NIAP comments for PP_MDF integration
 
 |===
@@ -262,11 +262,7 @@ As defined by the references <<CC1>>, <<CC2>> and <<CC3>>, when the Base-PP is t
 * all assurance requirements are inherited from the Base-PP,
 * does not claim conformance to any other security functional packages or Protection Profiles.
 
-The following PPs and PP-Modules are allowed to be specified in a PP-Configuration with this PP-Module:
-
-* PP-Module for Virtual Private Network (VPN) Clients, Version 2.3
-* PP-Module for MDM Agents, Version 1.0
-* PP-Module for Bluetooth, Version 1.0
+The PPs and PP-Modules that are allowed to be  specified in a PP-Configuration with this PP-Module can be found at the https://biometricitc.github.io/PP-allowed.html[Allowed Components] page on the Biometrics Security website.
 
 === Evaluation activities
 

--- a/Supporting Documents/BS_SD.adoc
+++ b/Supporting Documents/BS_SD.adoc
@@ -6,7 +6,7 @@
 :imagesdir: images
 :icons: font
 :revnumber: 1.1
-:revdate: July 19, 2022
+:revdate: September 12, 2022
 :xrefstyle: full
 :doctype: book
 
@@ -70,7 +70,7 @@ Biometric Security international Technical Community (BIO-iTC)
 |Technical Decision BIO0002
 
 |1.1
-|July 19, 2022
+|September 12, 2022
 |Incorporated TDs and NIAP comments for PP_MDF integration
 
 |===
@@ -1779,10 +1779,10 @@ The evaluator shall select “Moderate” because the number of unsuccessful aut
 - [#CC3]#[CC3]#	Common Criteria for Information Technology Security Evaluation, Part 3: Security Assurance Components, CCMB-2017-04-003, Version 3.1 Revision 5, April 2017.    
 - [#CEM]#[CEM]#	Common Methodology for Information Technology Security Evaluation, Evaluation Methodology, CCMB-2017-04-004, Version 3.1 Revision 5, April 2017.    
 - [#addenda]#[addenda]#	CC and CEM addenda, Exact Conformance, Selection-Based SFRs, Optional SFRs, Version 0.5, May 2017.        
-- [#PP_MDF]#[PP_MDF]# Protection Profile for Mobile Device Fundamentals, Version: 3.3.    
-- [#CFG-MDF-BIO]#[CFG-MDF-BIO]# PP-Configuration for Protection Profile for Mobile Device Fundamentals and collaborative PP-Module for Biometric enrolment and verification - for unlocking the device -, July 19, 2022, Version 1.1 - [CFG-MDF-BIO].    
-- [#BIOPP-Module]#[BIOPP-Module]# collaborative PP-Module for Biometric enrolment and verification - for unlocking the device -, July 19, 2022, Version 1.1 - [BIOPP-Module].
-- [#Toolbox]#[Toolbox]# Toolbox Overview, July 19, 2022, Version 1.1.
+- [#PP_MDF]#[PP_MDF]# Protection Profile for Mobile Device Fundamentals, September 12, 2022, Version 3.3.    
+- [#CFG-MDF-BIO]#[CFG-MDF-BIO]# PP-Configuration for Protection Profile for Mobile Device Fundamentals and collaborative PP-Module for Biometric enrolment and verification - for unlocking the device -, September 12, 2022, Version 1.1 - [CFG-MDF-BIO].    
+- [#BIOPP-Module]#[BIOPP-Module]# collaborative PP-Module for Biometric enrolment and verification - for unlocking the device -, September 12, 2022, Version 1.1 - [BIOPP-Module].
+- [#Toolbox]#[Toolbox]# Toolbox Overview, September 12, 2022, Version 1.1.
 - [#ISO19795-1]#[ISO/IEC 19795-1]# Biometric performance testing and reporting - Part 1: Principles and framework, First edition.    
 - [#ISO19795-2]#[ISO/IEC 19795-2]# Biometric performance testing and reporting - Part 2: Testing methodologies for technology and scenario evaluation, First edition.    
 - [#ISO19795-3]#[ISO/IEC 19795-3]# Biometric performance testing and reporting - Part 3: Modality-specific testing, First edition.


### PR DESCRIPTION
To match up with the PP_MDF release the following changes were made:

- release dates for the docs all changed to match with the dates of the PP_MDF date (September 12, 2022)
- The specific PP-Modules that are allowed was removed and replaced by a link to a new page on the website. This will prevent needing to revise the PPM every time NIAP publishes as new Module update as the website page can be done easily.
- in the PP-Config (which will not be used as NIAP will create their own), I changed the reference to the PPM to MOD_BIO_V1.0 which matches the NIAP format for the names