### PR TITLE
PAD L2+ udpate

### DIFF
--- a/Protection Profile/BiocPP.adoc
+++ b/Protection Profile/BiocPP.adoc
@@ -455,37 +455,11 @@ Target error rates defined in SFR shall be evaluated based on <<BIOSD>>. Normall
 
 ===== FIA_PAD_EXT.1 Presentation attack support [[FIA_PAD_EXT.1]]
 
-*FIA_PAD_EXT.1.1*:: The TSF shall provide the [*selection*: _biometric modality_] with [*selection*: _enrolment detection_] detection at biometric enrolment and [*selection*: _verification detection equal to or greater than enrolment detection_] detection at biometric verification.
+*FIA_PAD_EXT.1.1*:: The TSF shall provide the [*selection*: _eye, face, fingerprint, vein_] with [*selection*: _PAD-L3, PAD-L2, PAD-L1, no PAD_] detection as specified in FIA_MBE_EXT.3 during biometric enrolment and [*selection, equal or greater than enrolment*: _PAD-L3, PAD-L2, PAD-L1, no PAD_] detection as specified in FIA_MBV_EXT.3 during biometric verification.
 
-*Application Note {counter:remark_count}*:: The <<PAD_Levels>> table provides acceptable options for each modality by row for each selection within the SFR. Selecting a specific modality then specifies the options that are available for enrolment and verification detection.
+*Application Note {counter:remark_count}*:: Not all combinations of modality and PAD levels may be supported as PAD-L2 and PAD-L3 toolboxes are not publicly released.
 
 *Application Note {counter:remark_count}*:: The selection for the verification detection shall be at least equal to the selection for the enrolment detection. Choosing PAD (either L1 or L2 as appropriate) at enrolment means that at least the same level of PAD shall be selected for verification. Higher levels for verification can always be selected (such as No PAD at enrolment and any PAD level for verification or PAD-L1 for enrolment and PAD-L2 at verification).
-
-.Supported PAD levels
-[[PAD_levels]]
-[cols=".^1,.^2,.^2",options=header]
-|===
-|Biometric modality
-|Enrolment detection
-|Verification detection
-
-|eye 
-|{empty}[*selection*: [.underline]#PAD-L1 as specified in FIA_MBE_EXT.3, no PAD#]
-|{empty}[*selection*: [.underline]#PAD-L1 as specified in FIA_MBV_EXT.3, no PAD#]
-
-|face
-|{empty}[*selection*: [.underline]#PAD-L2 as specified in FIA_MBE_EXT.3, PAD-L1 as specified in FIA_MBE_EXT.3, no PAD#]
-|{empty}[*selection*: [.underline]#PAD-L2 as specified in FIA_MBV_EXT.3, PAD-L1 as specified in FIA_MBV_EXT.3, no PAD#]
-
-|fingerprint
-|{empty}[*selection*: [.underline]#PAD-L2 as specified in FIA_MBE_EXT.3, PAD-L1 as specified in FIA_MBE_EXT.3, no PAD#]
-|{empty}[*selection*: [.underline]#PAD-L2 as specified in FIA_MBV_EXT.3, PAD-L1 as specified in FIA_MBV_EXT.3, no PAD#]
-
-|vein
-|{empty}[*selection*: [.underline]#PAD-L1 as specified in FIA_MBE_EXT.3, no PAD#]
-|{empty}[*selection*: [.underline]#PAD-L1 as specified in FIA_MBV_EXT.3, no PAD#]
-
-|===
 
 ==== Protection of the TSF (FPT)
 ===== FPT_BDP_EXT.1 Biometric data processing [[FPT_BDP_EXT.1]]
@@ -693,7 +667,7 @@ ST authors are free to choose none, some or all SFRs defined in this Section. Ju
 
 ==== FIA_MBV_EXT.3 Presentation attack detection for biometric verification [[FIA_MBV_EXT.3]]
 
-*FIA_MBV_EXT.3.1*:: The TSF shall provide a biometric verification mechanism with the IAPAR not exceeding [*selection*: _value equal to or less than 7% (7:100) if FIA_PAD_EXT.1.1 selects PAD-L2, _value equal to or less than 15% (15:100) if FIA_PAD_EXT.1.1 selects PAD-L1_] to prevent use of artificial presentation attack instruments from being successfully verified.
+*FIA_MBV_EXT.3.1*:: The TSF shall provide a biometric verification mechanism with the IAPAR not exceeding [*selection*: _value equal to or less than 7% (7:100) if FIA_PAD_EXT.1.1 selects PAD-L2 or higher, _value equal to or less than 15% (15:100) if FIA_PAD_EXT.1.1 selects PAD-L1_] to prevent use of artificial presentation attack instruments from being successfully verified.
 
 *Application Note {counter:remark_count}*:: <<BIOSD>> provides instructions how to produce and present the artificial presentation attack instruments.
 
@@ -870,7 +844,7 @@ FIA_MBE_EXT.1 Biometric enrolment
 
 FIA_MBV_EXT.1 Biometric verification
 
-*FIA_MBV_EXT.3.1*:: The TSF shall provide a biometric verification mechanism with the IAPAR not exceeding [*selection*: _value equal to or less than 7% (7:100) if FIA_PAD_EXT.1.1 selects PAD-L2, _value equal to or less than 15% (15:100) if FIA_PAD_EXT.1.1 selects PAD-L1_] to prevent use of artificial presentation attack instruments from being successfully verified.
+*FIA_MBV_EXT.3.1*:: The TSF shall provide a biometric verification mechanism with the IAPAR not exceeding [*selection*: _value equal to or less than 7% (7:100) if FIA_PAD_EXT.1.1 selects PAD-L2 or higher, _value equal to or less than 15% (15:100) if FIA_PAD_EXT.1.1 selects PAD-L1_] to prevent use of artificial presentation attack instruments from being successfully verified.
 
 ==== Presentation Attack Detection (FIA_PAD_EXT)
 ===== Family Behaviour
@@ -901,33 +875,7 @@ Hierarchical to: No other components
 
 Dependencies: No dependencies
 
-*FIA_PAD_EXT.1.1*:: The TSF shall provide the [*selection*: _biometric modality_] with [*selection*: _enrolment detection_] detection at biometric enrolment and [*selection*: _verification detection_] detection at biometric verification.
-
-.Supported PAD levels
-[[PAD_levelsECD]]
-[cols=".^1,.^2,.^2",options=header]
-|===
-|Biometric modality
-|Enrolment detection
-|Verification detection
-
-|eye 
-|{empty}[*selection*: [.underline]#PAD-L1 as specified in FIA_MBE_EXT.3, no PAD#]
-|{empty}[*selection*: [.underline]#PAD-L1 as specified in FIA_MBV_EXT.3, no PAD#]
-
-|face
-|{empty}[*selection*: [.underline]#PAD-L2 as specified in FIA_MBE_EXT.3, PAD-L1 as specified in FIA_MBE_EXT.3, no PAD#]
-|{empty}[*selection*: [.underline]#PAD-L2 as specified in FIA_MBV_EXT.3, PAD-L1 as specified in FIA_MBV_EXT.3, no PAD#]
-
-|fingerprint
-|{empty}[*selection*: [.underline]#PAD-L2 as specified in FIA_MBE_EXT.3, PAD-L1 as specified in FIA_MBE_EXT.3, no PAD#]
-|{empty}[*selection*: [.underline]#PAD-L2 as specified in FIA_MBV_EXT.3, PAD-L1 as specified in FIA_MBV_EXT.3, no PAD#]
-
-|vein
-|{empty}[*selection*: [.underline]#PAD-L1 as specified in FIA_MBE_EXT.3, no PAD#]
-|{empty}[*selection*: [.underline]#PAD-L1 as specified in FIA_MBV_EXT.3, no PAD#]
-
-|===
+*FIA_PAD_EXT.1.1*:: The TSF shall provide the [*selection*: _eye, face, fingerprint, vein_] with [*selection*: _PAD-L3, PAD-L2, PAD-L1, no PAD_] detection as specified in FIA_MBE_EXT.3 during biometric enrolment and [*selection, equal or greater than enrolment*: _PAD-L3, PAD-L2, PAD-L1, no PAD_] detection as specified in FIA_MBV_EXT.3 during biometric verification.
 
 === Protection of the TSF (FPT)
 ==== Biometric data processing (FPT_BDP_EXT)


### PR DESCRIPTION
This change is to incorporate PAD-L3 into the SFRs and removing the specific enumeration of PAD for each modality.