### PR TITLE
BMD conditional comment

### DIFF
--- a/Supporting Documents/BS_SD.adoc
+++ b/Supporting Documents/BS_SD.adoc
@@ -624,8 +624,8 @@ Following input is required from the developer.
 
 [loweralpha]
 . TSS shall explain how the TOE meets FPT_BDP_EXT.1 at high level description
-. BMD may be used to provide additional details about the protection mechanisms provided by the SEE and environment
-. BMD may be used to provide details about TSFIs that may provide the capability to export plaintext biometric data but which must be disabled/blocked for use in the evaluated configuration
+. TSS or BMD shall provide additional details about the protection mechanisms provided by the SEE and environment
+. TSS or BMD shall provide details about TSFIs that may provide the capability to export plaintext biometric data but which must be disabled/blocked for use in the evaluated configuration
 
 ===== Assessment Strategy
 


### PR DESCRIPTION
This is to close #435. I did not see any other instances of this. Instead of making it conditional, since the information is required I wrote it that either the TSS or BMD has to include the information, so it is up to the developer to decide what to put where, but that it has to be available.