### PR TITLE
Update on Brian's proposal

### DIFF
--- a/Supporting Documents/BS_SD.adoc
+++ b/Supporting Documents/BS_SD.adoc
@@ -1539,7 +1539,7 @@ Exploitation corresponds to achieving the attack on an instance of the TOE in it
 
 ==== Factors to be considered
 
-As in the [CEM], the factors to be considered consist of *_Elapsed time_*, *_Expertise_*, *_Knowledge of the TOE_*, *_Equipment_*, *_Window of opportunity_* and *_Degree of Scrutiny_*. But *_Window of opportunity_* is divided into two subfactors *_Window of opportunity (Access to the TOE)_* and *_Window of opportunity (Access to biometric characteristics)_*. 
+As in the <<CEM>>, the factors to be considered consist of *_Elapsed time_*, *_Expertise_*, *_Knowledge of the TOE_*, *_Equipment_*, *_Window of opportunity_* and *_Degree of Scrutiny_*. But *_Window of opportunity_* is divided into two subfactors *_Window of opportunity (Access to the TOE)_* and *_Window of opportunity (Access to biometric characteristics)_*. 
 
 *_Elapsed time_* is the total amount of time taken by the attacker.
 
@@ -1598,9 +1598,9 @@ The levels are as follows:
 [loweralpha]
 . _Not needed_ is for attacks that do not need real biometric data to be available, for example, attacks based on synthetic images or template generation.
 . _Without notice (Easy)_ is for making an artefact with samples that can be collected without any contact with an enroled subject. For example, 2D face images uploaded on the Internet and latent fingerprint images on a glass can be collected without notice of the subject.
-. _Without notice (Enhanced-Easy)_ is for making an artefact with samples that can be collected without any contact with an enroled subject, but for which the identity of the subject is not known prior to the attack, as in a target of opportunity vs a planned attack. In this case, while the necessary images may not be difficult to acquire, they may have to be acquired after the attack has started instead of beforehand.
+. _Opportunistic Easy (Enhanced-Easy)_ is for making an artefact with samples that can be collected without any contact with an enroled subject, but for which the identity of the subject is not known prior to the attack, as in a target of opportunity vs a planned attack. In this case, while the necessary images may not be difficult to acquire, they may have to be acquired after the attack has started instead of beforehand.
 . _Non-cooperative (Moderate)_ is for making an artefact with samples that need to be collected directly from an enroled subject in a short period of time without conscious cooperation from the subject. For example, iris or vein images need to be acquired with a high resolution or infrared camera, however, such images can be taken in a moment without conscious control of the subject.
-. _Cooperative(Difficult)_ is for making an artefact with samples that need to be collected directly from an enroled subject with full cooperation from the subject. For example, the acquisition of a detailed 3D face scan of the subject takes time and requires full cooperation from the subject.
+. _Cooperative (Difficult)_ is for making an artefact with samples that need to be collected directly from an enroled subject with full cooperation from the subject. For example, the acquisition of a detailed 3D face scan of the subject takes time and requires full cooperation from the subject.
 
 *_Window of opportunity (Access to the TOE)_* refers to measuring the difficulty to access the TOE either to prepare the attack or to perform it on the target system.
 
@@ -1923,7 +1923,6 @@ The evaluator shall select "None" because potential difficulties to having acces
 - [#ISO29794-4]#[ISO/IEC 29794-4]# Information technology — Biometric sample quality - Part 4: Finger image data, First edition.
 - [#ISO30107-3]#[ISO/IEC 30107-3]# Biometric presentation attack detection - Part 3: Testing and reporting, First edition.
 - [#ISO30107-4]#[ISO/IEC 30107-4]# Biometric presentation attach detection - Part 4: Profile for testing of mobile devices, First edition.
-- [#BEAT]#[BEAT]# Biometrics Evaluation and Testing, https://www.beat-eu.org.
 - [#Qualifying Fingerprint Samples]#[Qualifying Fingerprint Samples]# Qualifying Fingerprint Samples Captured by Smartphone Cameras in Real-Life Scenarios - May 3, 2016, http://hdl.handle.net/11250/2388306.
 - [#Performance of Biometric Quality]#[Performance of Biometric Quality]# Performance of Biometric Quality Measures - April 16, 2007, https://www.nist.gov/publications/performance-biometric-quality-measures.
 - [#Ongoing Face Recognition Vendor Test]#[Ongoing Face Recognition Vendor Test]# Ongoing Face Recognition Vendor Test (FRVT) Part 5: Face Image Quality Assessment - August 11, 2021, https://pages.nist.gov/frvt/reports/quality/frvt_quality_report.pdf.

--- a/Supporting Documents/BS_SD.adoc
+++ b/Supporting Documents/BS_SD.adoc
@@ -1504,7 +1504,23 @@ Same as <<Methods to create low-quality samples>>
 
 === Calculating attack potential for generic biometric system
 
-Attack potential is a function of expertise, resources and motivation, as is written in <<CEM>>. The <<CEM>> provides general guidance for calculating attack potential for all type of IT products and doesn't take any specific characteristics of biometrics into account. The iTC, building on the expertise of the membership, ongoing work at <<ISO/IEC 19989-1,ISO 19989>>, <<ISO/IEC 25456-1,ISO 25456>> and the <<BEAT>> project, has tailored the guidance more specifically for biometrics.
+Attack potential is a function of expertise, resources and motivation, as is written in <<CEM>>. The <<CEM>> provides general guidance for calculating attack potential for all type of IT products and this general guidance should be adjusted considering the specific characteristics of a particular type of IT products.
+
+Currently, two ISO standards, <<ISO/IEC 19989-1,ISO 19989>> and <<ISO/IEC 25456,ISO 25456>> have tailored the guidance more specifically for biometrics. <<ISO/IEC 19989-1,ISO 19989>> and <<ISO/IEC 25456,ISO 25456>> define the framework for the PAD and biometric data injection attack detection evaluation respectively. There is similarity between both frameworks, however, there is a fundamental difference between the two.
+
+<<ISO/IEC 19989-1,ISO 19989>> framework is conformant to the <<CC>> and <<CEM>> (This <<SD>> is also conformant to the <<CC>> and <<CEM>> however, its scope is limited to AVA_VAN.1). Biometric product evaluations under <<ISO/IEC 19989-1,ISO 19989>> shall meet all requirements defined in <<ISO/IEC 19989-1,ISO 19989>>, the <<CC>> and <<CEM>>. The level of AVA_VAN component that the TOE shall meet determines the level of resistance to attacks and evidence (e.g., design, configuration management or development lifecycle document) required for the evaluations. 
+
+On the other hand, <<ISO/IEC 25456,ISO 25456>> is not conformant to <CC>> and <<CEM>> and doesn’t use the AVA_VAN component. Instead, <<ISO/IEC 25456,ISO 25456>> reduces the number of requirements to enable the fixed-time evaluations and provides detail and specific guidance for the penetration testing.
+
+However, both standards share almost the same attack potential table because the measure to gauge the level of presentation attack and biometric data injection attack should be consistent. Differences between the table in <<ISO/IEC 19989-1,ISO 19989>> and <<ISO/IEC 25456,ISO 25456>> are;
+
+[loweralpha]
+. <<ISO/IEC 25456,ISO 25456>> includes additional factor, Degree of Scrutiny and a level _Not needed_ in *Window of Opportunity (Access to Biometric Characteristics)*. This factor and level can’t apply to mobile devices and values for this factor and level are all specified as *Not applicable* in the attack potential table.   
+. <<ISO/IEC 19989-1,ISO 19989>> adds a new level _Opportunistic Easy (Enhanced-Easy)_ to *Window of Opportunity (Access to Biometric Characteristics)* and defines higher values for *Window of Opportunity (Access to TOE)* in exploitation phase considering the nature of mobile devices.  
+. Both standards define a few factors with different name (e.g., *Elapsed Time* in <<ISO/IEC 19989-1,ISO 19989>> and *Time effort* in <<ISO/IEC 25456,ISO 25456>>). 
+. Guidance for factors in <<ISO/IEC 19989-1,ISO 19989>> is adjusted to the presentation attack and different from ones in <<ISO/IEC 25456,ISO 25456>>.
+
+This <<SD>> defines the same attack potential table and guidance as defined in <<ISO/IEC 19989-1,ISO 19989>>.
 
 This section introduces a method for calculating attack potential for generic biometric systems.
 
@@ -1901,8 +1917,8 @@ The evaluator shall select “Moderate” because the number of unsuccessful aut
 - [#ISO19795-1]#[ISO/IEC 19795-1]# Biometric performance testing and reporting - Part 1: Principles and framework, First edition.    
 - [#ISO19795-2]#[ISO/IEC 19795-2]# Biometric performance testing and reporting - Part 2: Testing methodologies for technology and scenario evaluation, First edition.    
 - [#ISO19795-3]#[ISO/IEC 19795-3]# Biometric performance testing and reporting - Part 3: Modality-specific testing, First edition.
-- [#ISO19989-1]#[ISO/IEC 19989-1]# Criteria and methodology for security evaluation of biometric systems - Part 1: Framework, Under development.  
-- [#ISO25456-1]#[ISO/IEC 25456-1]# Criteria and methodology for security evaluation of biometric systems - Part 1: Framework, Under development.  
+- [#ISO19989-1]#[ISO/IEC 19989-1]# Criteria and methodology for security evaluation of biometric systems - Part 1: Framework, Under revision.  
+- [#ISO25456]#[ISO/IEC 25456]# Biometrics — Biometric data injection attack detection, Under development.  
 - [#ISO29794-1]#[ISO/IEC 29794-1]# Information technology — Biometric sample quality - Part 1: Framework, First edition.
 - [#ISO29794-4]#[ISO/IEC 29794-4]# Information technology — Biometric sample quality - Part 4: Finger image data, First edition.
 - [#ISO30107-3]#[ISO/IEC 30107-3]# Biometric presentation attack detection - Part 3: Testing and reporting, First edition.

--- a/Supporting Documents/BS_SD.adoc
+++ b/Supporting Documents/BS_SD.adoc
@@ -1598,7 +1598,7 @@ The levels are as follows:
 [loweralpha]
 . _Not needed_ is for attacks that do not need real biometric data to be available, for example, attacks based on synthetic images or template generation.
 . _Without notice (Easy)_ is for making an artefact with samples that can be collected without any contact with an enroled subject. For example, 2D face images uploaded on the Internet and latent fingerprint images on a glass can be collected without notice of the subject.
-. _Without notice (Enhanced-Easy)_ is for ? (*Brian please add description here*).
+. _Without notice (Enhanced-Easy)_ is for making an artefact with samples that can be collected without any contact with an enroled subject, but for which the identity of the subject is not known prior to the attack, as in a target of opportunity vs a planned attack. In this case, while the necessary images may not be difficult to acquire, they may have to be acquired after the attack has started instead of beforehand.
 . _Non-cooperative (Moderate)_ is for making an artefact with samples that need to be collected directly from an enroled subject in a short period of time without conscious cooperation from the subject. For example, iris or vein images need to be acquired with a high resolution or infrared camera, however, such images can be taken in a moment without conscious control of the subject.
 . _Cooperative(Difficult)_ is for making an artefact with samples that need to be collected directly from an enroled subject with full cooperation from the subject. For example, the acquisition of a detailed 3D face scan of the subject takes time and requires full cooperation from the subject.
 

--- a/Supporting Documents/BS_SD.adoc
+++ b/Supporting Documents/BS_SD.adoc
@@ -1508,19 +1508,18 @@ Attack potential is a function of expertise, resources and motivation, as is wri
 
 Currently, two ISO standards, <<ISO/IEC 19989-1,ISO 19989>> and <<ISO/IEC 25456,ISO 25456>> have tailored the guidance more specifically for biometrics. <<ISO/IEC 19989-1,ISO 19989>> and <<ISO/IEC 25456,ISO 25456>> define the framework for the PAD and biometric data injection attack detection evaluation respectively. There is similarity between both frameworks, however, there is a fundamental difference between the two.
 
-<<ISO/IEC 19989-1,ISO 19989>> framework is conformant to the <<CC>> and <<CEM>> (This <<SD>> is also conformant to the <<CC>> and <<CEM>> however, its scope is limited to AVA_VAN.1). Biometric product evaluations under <<ISO/IEC 19989-1,ISO 19989>> shall meet all requirements defined in <<ISO/IEC 19989-1,ISO 19989>>, the <<CC>> and <<CEM>>. The level of AVA_VAN component that the TOE shall meet determines the level of resistance to attacks and evidence (e.g., design, configuration management or development lifecycle document) required for the evaluations. 
+<<ISO/IEC 19989-1,ISO 19989>> framework is conformant to the <<CC>> and <<CEM>> (This BIOSD is also conformant to the <<CC>> and <<CEM>> however, its scope is limited to AVA_VAN.1). Biometric product evaluations under <<ISO/IEC 19989-1,ISO 19989>> shall meet all requirements defined in <<ISO/IEC 19989-1,ISO 19989>>, the <<CC>> and <<CEM>>. The level of AVA_VAN component that the TOE shall meet determines the level of resistance to attacks and evidence (e.g., design, configuration management or development lifecycle document) required for the evaluations. 
 
-On the other hand, <<ISO/IEC 25456,ISO 25456>> is not conformant to <CC>> and <<CEM>> and doesn’t use the AVA_VAN component. Instead, <<ISO/IEC 25456,ISO 25456>> reduces the number of requirements to enable the fixed-time evaluations and provides detail and specific guidance for the penetration testing.
+On the other hand, <<ISO/IEC 25456,ISO 25456>> is not conformant to <<CC>> and <<CEM>> and doesn’t use the AVA_VAN component. Instead, <<ISO/IEC 25456,ISO 25456>> reduces the number of requirements to enable the fixed-time evaluations and provides detail and specific guidance for the penetration testing.
 
 However, both standards share almost the same attack potential table because the measure to gauge the level of presentation attack and biometric data injection attack should be consistent. Differences between the table in <<ISO/IEC 19989-1,ISO 19989>> and <<ISO/IEC 25456,ISO 25456>> are;
 
 [loweralpha]
-. <<ISO/IEC 25456,ISO 25456>> includes additional factor, Degree of Scrutiny and a level _Not needed_ in *Window of Opportunity (Access to Biometric Characteristics)*. This factor and level can’t apply to mobile devices and values for this factor and level are all specified as *Not applicable* in the attack potential table.   
-. <<ISO/IEC 19989-1,ISO 19989>> adds a new level _Opportunistic Easy (Enhanced-Easy)_ to *Window of Opportunity (Access to Biometric Characteristics)* and defines higher values for *Window of Opportunity (Access to TOE)* in exploitation phase considering the nature of mobile devices.  
-. Both standards define a few factors with different name (e.g., *Elapsed Time* in <<ISO/IEC 19989-1,ISO 19989>> and *Time effort* in <<ISO/IEC 25456,ISO 25456>>). 
+. <<ISO/IEC 19989-1,ISO 19989>> adds a new level _⇐ twelve hours_ to *Elapsed Time* and _Opportunistic Easy (Enhanced-Easy)_ to *Window of Opportunity (Access to Biometric Characteristics)* and defines higher values for *Window of Opportunity (Access to TOE)* in exploitation phase considering the nature of mobile devices.  
+. Both standards define a few same factors with different name (e.g., *Elapsed Time* in <<ISO/IEC 19989-1,ISO 19989>> and *Time effort* in <<ISO/IEC 25456,ISO 25456>>). 
 . Guidance for factors in <<ISO/IEC 19989-1,ISO 19989>> is adjusted to the presentation attack and different from ones in <<ISO/IEC 25456,ISO 25456>>.
 
-This <<SD>> defines the same attack potential table and guidance as defined in <<ISO/IEC 19989-1,ISO 19989>>.
+This BIOSD defines the same attack potential table and guidance as defined in <<ISO/IEC 19989-1,ISO 19989>>.
 
 This section introduces a method for calculating attack potential for generic biometric systems.
 
@@ -1540,15 +1539,13 @@ Exploitation corresponds to achieving the attack on an instance of the TOE in it
 
 ==== Factors to be considered
 
-As in the <<CEM>>, the factors to be considered consist of *_Elapsed time_*, *_Expertise_*, *_Knowledge of the TOE_*, *_Equipment_*, *_Window of opportunity_*, and *_Degree of Scrutiny_*. But *_Window of opportunity_* is divided into two subfactors *_Window of opportunity (Access to the TOE)_*, *_Window of opportunity (Access to biometric characteristics)_*.
+As in the [CEM], the factors to be considered consist of *_Elapsed time_*, *_Expertise_*, *_Knowledge of the TOE_*, *_Equipment_*, *_Window of opportunity_* and *_Degree of Scrutiny_*. But *_Window of opportunity_* is divided into two subfactors *_Window of opportunity (Access to the TOE)_* and *_Window of opportunity (Access to biometric characteristics)_*. 
 
 *_Elapsed time_* is the total amount of time taken by the attacker.
 
 In the identification phase, elapsed time corresponds to the time required to create the attack, and to demonstrate that it can be successfully applied to the TOE (including setting up or building any necessary hardware or software equipment). The demonstration that the attack can be successfully applied needs to consider any difficulties in expanding a result shown in the laboratory to create a useful attack. One of the outputs from identification is, for instance, a script that gives a step-by-step description of how to carry out the attack. This script is assumed to be used in the exploitation part.
 
 In the exploitation phase, elapsed time corresponds to the time necessary to apply the "script" to specific biometric characteristics. For example, for a presentation attack to a fingerprint capture device, it corresponds to the time required to create an artefact from an image of a print (and not the acquisition of this image which is taken into account in the factor *_Window of opportunity (Access to biometric characteristics)_*).
-
-Potential difficulties to having access to the TOE in the exploitation environment are taken into account in the factor *_Window of opportunity (Access to the TOE)_* and where applicable, the *_Degree of Scrutiny_*, though for mobile devices, the *_Degree of Scrutiny_* is assumed to be none.
 
 *_Expertise_* refers to the level of proficiency required by the attacker and the general knowledge that he possesses, not specific of the system being attacked. The levels are as follows:
 
@@ -1576,7 +1573,7 @@ This information could be publicly available at the website of the capture devic
 
 Special attention should be paid in this point to possible countermeasures that may be implemented in the system and whether it is necessary or not to have knowledge of their existence in order to be successful in a given attack.
 
-It is assumed that all the knowledge required to perform the attack is gained during the identification phase and "scripted" for the exploitation. Therefore, this factor is not used for the exploitation phase.
+It is assumed that all the knowledge required to perform the attack is gained during the identification phase and "scripted" for the exploitation. Therefore, this factor is rarely used for the exploitation phase and should be justified by the evaluator when using it.
 
 *_Equipment_* refers to the type of equipment required to perform the attack. This includes the biometric databases used (if any). The levels are follows:
 
@@ -1592,16 +1589,18 @@ _Not practical_ refers to equipment that is too expensive or too difficult to ob
 
 *_Window of opportunity (Access to biometric characteristics)_* refers to measuring the difficulty to access the target biometric characteristics either to prepare the attack or to perform it on the target system
 
-Security evaluations of CC are dedicated to evaluate the intrinsic resistance of a system. Due to the potential number of attack paths (with or without the cooperation of an enroled subject for example) the evaluation does not take into account the way a real biometric characteristic is acquired. For presentation attack detection, the vulnerability analysis is based on the hypothesis that a real "image" is available, and the rating only concerns the creation and the presentation of an artefact.
+Security evaluations of CC are dedicated to evaluate the intrinsic resistance of a system. Due to the potential number of attack paths (with or without the cooperation of an enroled subject for example) the evaluation does not take into account the way a real biometric characteristic is acquired. For presentation attack detection, the vulnerability analysis is based on the hypothesis that a real "image" is available except for cases that use synthetic images, and the rating only concerns the creation and the presentation of an artefact.
 
 However, it is important to be able to compare the resistance of various systems, even based on different biometrics. In addition, getting a real "image" to build an artefact is clearly part of an attack and it is of interest, for the final user of the TOE and the pertinence of a certificate to add a factor related to this aspect.
 
 The levels are as follows:
 
 [loweralpha]
-. _Without notice_ is for making an artefact with samples that can be collected without any contact with an enroled subject. For example, 2D face images uploaded on the Internet and latent fingerprint images on a glass can be collected without notice of the subject.
-. _Non-cooperative_ is for making an artefact with samples that need to be collected directly from an enroled subject in a short period of time without conscious cooperation from the subject. For example, iris or vein images need to be acquired with a high resolution or infrared camera, however, such images can be taken in a moment without conscious control of the subject.
-. _Cooperative_ is for making an artefact with samples that need to be collected directly from an enroled subject with full cooperation from the subject. For example, the acquisition of a detailed 3D face scan of the subject takes time and requires full cooperation from the subject.
+. _Not needed_ is for attacks that do not need real biometric data to be available, for example, attacks based on synthetic images or template generation.
+. _Without notice (Easy)_ is for making an artefact with samples that can be collected without any contact with an enroled subject. For example, 2D face images uploaded on the Internet and latent fingerprint images on a glass can be collected without notice of the subject.
+. _Without notice (Enhanced-Easy)_ is for ? (*Brian please add description here*).
+. _Non-cooperative (Moderate)_ is for making an artefact with samples that need to be collected directly from an enroled subject in a short period of time without conscious cooperation from the subject. For example, iris or vein images need to be acquired with a high resolution or infrared camera, however, such images can be taken in a moment without conscious control of the subject.
+. _Cooperative(Difficult)_ is for making an artefact with samples that need to be collected directly from an enroled subject with full cooperation from the subject. For example, the acquisition of a detailed 3D face scan of the subject takes time and requires full cooperation from the subject.
 
 *_Window of opportunity (Access to the TOE)_* refers to measuring the difficulty to access the TOE either to prepare the attack or to perform it on the target system.
 
@@ -1614,12 +1613,9 @@ The number and the level of equipment requested to build the attack is also take
 This factor is not expressed in terms of time. The levels are as follows:
 
 [loweralpha]
-. _Not needed_: For the attack phase, there is no need to have access to the TOE.
 . _Easy_: For identification phase, there is no strong constraint for the attacker to buy the TOE (reasonable price) to prepare its attack. For exploitation phase, there is no limit in the number of tries and the presentation attack is difficult to detect.
 . _Moderate_: For identification phase, specialised distribution schemes exist (not available to individuals). For exploitation phase, either a tuning of the attack for the final system is required (unknown parameterization of countermeasures for example) or there are constraints such as having to steal the device where the owner of the system would become aware of the missing device within some defined time period.
 . _Difficult_: For identification phase, the system is not available except for identified users and access requires compromising of one of the actors. For exploitation phase, for example artefacts must be adapted to the (unknown) specific tuning, or the system needs physical modification (for example physically accessing a hidden signal significant to the comparison score).
-
-*Application Note {counter:remark_count}*:: Rating the resistance of a system is based on rating the successful attacks and verifying that no successful attack is found at the targeted level. Some attacks do not need real biometric data to be available, for example, attacks based on synthetic images or template generation. In such a case, this factor has to be considered to be _Without notice_.
 
 *_Degree of Scrutiny_* refers to the amount of examination or oversight applied during the use of the TOE for authentication. 
 
@@ -1900,6 +1896,10 @@ The evaluator shall select “Easy” because the TOE is a computer that anyone 
 ==== Application note for Window of Opportunity (Access to TOE) for Exploitation
 
 The evaluator shall select “Moderate” because the number of unsuccessful authentication attempts for biometric verification is limited, and biometric verification becomes unusable if the number of failure attempts exceed the limit.
+
+==== Application note for Degree of Scrutiny for Identification and Exploitation
+
+The evaluator shall select "None" because potential difficulties to having access to the TOE are taken into account in the factor *_Window of opportunity (Access to the TOE)_* for mobile devices.
 
 == Related Documents
 [bibliography]


### PR DESCRIPTION
I updated Brian's proposal and working draft for 19989-1 will also be updated in the same way, however there are two issues.

1) description for **Without notice (Enhanced-Easy)** should be added.
2) there are the following differnce between 19989 and 24546 but these difference may be harmonized during the editing in the future.

_[ISO 19989] adds a new level ⇐ twelve hours to Elapsed Time and Opportunistic Easy (Enhanced-Easy) to Window of Opportunity (Access to Biometric Characteristics) and defines higher values for Window of Opportunity (Access to TOE) in exploitation phase considering the nature of mobile devices._

_Both standards define a few same factors with different name (e.g., Elapsed Time in [ISO 19989] and Time effort in [ISO 25456])._

_Guidance for factors in [ISO 19989] is adjusted to the presentation attack and different from ones in [ISO 25456]._