### PR TITLE
Update equipment section in AP table

### DIFF
--- a/Supporting Documents/BS_SD.adoc
+++ b/Supporting Documents/BS_SD.adoc
@@ -1719,21 +1719,25 @@ The levels are as follows:
 
 3+|*Equipment*
 
-|Standard 
+|None 
 |0 
 |0
 
+|Standard 
+|1 
+|2
+
 |Specialised 
-|2 
+|3 
 |4
 
 |Bespoke 
-|4 
+|5 
 |6
 
 |Multiple Bespoke
-|6
-|10
+|7
+|8
 
 |Not practical
 |*


### PR DESCRIPTION
I compared values in our AP table and ones in smartcard AP table (*1)

Both tables have the same factors, Elapsed time, Expertise, Knowledge of TOE and Equipment.
Values in Expertise and Knowledge of TOE for both table are the same but values in Equipment in smartcard AP table is "None (0 0)" and "Standard (1 2)"  but our table doesn't have "None" and start from "Standard (0 0)".   Our AP talbe should follow the smartcard table as much as possible if there is no clear reason.

*1) https://certification.enisa.europa.eu/document/download/836d47eb-13cf-4415-beb6-df106582f1c1_en?filename=EUCC_state_of_the_art_attack%20potential%20to%20smart%20cards%20%20v2%20%28final.pdf